### PR TITLE
Image carousel crop fix

### DIFF
--- a/MESS/MESS.Blazor/Components/Carousel/Carousel.razor
+++ b/MESS/MESS.Blazor/Components/Carousel/Carousel.razor
@@ -97,9 +97,10 @@
     /// <summary>
     /// CSS styling to apply to the images within the carousel.
     /// Default styling sets a fixed height and object-fit: cover.
+    /// At the moment, this is overidden by styling in StepNodeListItem.razor
     /// </summary>
     [Parameter]
-    public string ImageStyle { get; set; } = "height: 300px; object-fit: cover;";
+    public string ImageStyle { get; set; } = "height: 300px; object-fit: contain;";
 
     /// <summary>
     /// Unique identifier for the carousel DOM element.

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -37,7 +37,7 @@
                         Images="@GetCombinedMedia()"
                         AutoPlay="false"
                         Interval="3000"
-                        ImageStyle="height: 400px; object-fit: cover;"/>
+                        ImageStyle= "max-width: 100%; height: auto; object-fit: contain;"/>
                 </div>
 
             </div>


### PR DESCRIPTION
This small pull request tweaks the way images are displayed in the image carousel. The image carousel now changes shape based upon the aspect ratio of the spreadsheet image. Previously, images would be cropped. The changes made in this pull request may have to be looked over again if images are too big to be convenient.