### PR TITLE
Multiple failure support

### DIFF
--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
@@ -484,9 +484,8 @@ public partial class Create : ComponentBase, IAsyncDisposable
             var result = false;
             await Task.Run(() =>
             {
-                // Check if all steps have at least one successful attempt
-                result = ProductionLog.LogSteps.All(step => 
-                    step.Attempts.Any(a => a.Success == true));
+                result = ProductionLog.LogSteps.All(step =>
+                    step.Attempts.Any(a => a.SubmitTime != DateTimeOffset.MinValue));
             });
 
             return result;

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
@@ -106,21 +106,20 @@ public partial class Create : ComponentBase, IAsyncDisposable
         if (cachedFormData != null && cachedFormData.LogSteps.Count != 0)
         {
             WorkInstructionStatus = Status.InProgress;
+
             ProductionLog = new ProductionLog
             {
                 Id = cachedFormData.ProductionLogId,
                 LogSteps = cachedFormData.LogSteps.Select(step => new ProductionLogStep
                 {
                     WorkInstructionStepId = step.WorkInstructionStepId,
-                    Attempts = new List<ProductionLogStepAttempt>
+                    ProductionLogId = step.ProductionLogId,
+                    Attempts = step.Attempts.Select(a => new ProductionLogStepAttempt
                     {
-                        new ProductionLogStepAttempt
-                        {
-                            Success = step.Attempts.Last().Success,
-                            Notes = step.Attempts.Last().Notes ?? "",
-                            SubmitTime = step.Attempts.Last().SubmitTime
-                        }
-                    }
+                        Success = a.Success,
+                        Notes = a.Notes ?? "",
+                        SubmitTime = a.SubmitTime
+                    }).ToList()
                 }).ToList()
             };
         }
@@ -129,8 +128,8 @@ public partial class Create : ComponentBase, IAsyncDisposable
             return false;
         }
 
-        if (ProductionLog.LogSteps.All(step => 
-                step.Attempts.Any(a => a.SubmitTime != DateTimeOffset.MinValue))) 
+        if (ProductionLog.LogSteps.All(step =>
+                step.Attempts.Any(a => a.SubmitTime != DateTimeOffset.MinValue)))
         {
             WorkInstructionStatus = Status.Completed;
         }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
@@ -418,17 +418,6 @@ public partial class Create : ComponentBase, IAsyncDisposable
         if (ActiveWorkInstruction == null)
             return;
     
-        var currentTime = DateTimeOffset.UtcNow;
-    
-        // Create a new attempt
-        var attempt = new ProductionLogStepAttempt
-        {
-            Success = success,
-            SubmitTime = success == null ? DateTimeOffset.MinValue : currentTime
-        };
-    
-        step.Attempts.Add(attempt);
-    
         await ProductionLogEventService.SetCurrentProductionLog(ProductionLog);
         var currentStatus = await GetWorkInstructionStatus();
         WorkInstructionStatus = currentStatus ? Status.Completed : Status.InProgress;

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/Create.razor.cs
@@ -130,7 +130,7 @@ public partial class Create : ComponentBase, IAsyncDisposable
         }
 
         if (ProductionLog.LogSteps.All(step => 
-                step.Attempts.Any(a => a.Success == true)))
+                step.Attempts.Any(a => a.SubmitTime != DateTimeOffset.MinValue))) 
         {
             WorkInstructionStatus = Status.Completed;
         }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -59,7 +59,7 @@
 <div class="row mt-3">
     <div class="col text-end">
         <input type="radio"
-               checked="@IsStepSuccessful(LogStep)"
+               checked="@(GetStepSuccessState(LogStep) == true)"
                autocomplete="off"
                class="btn-check"
                name="radioBtn{@Step.Name}"
@@ -68,7 +68,7 @@
         <label class="btn btn-outline-success @(!string.IsNullOrEmpty(SelectedButton) && SelectedButton == "Success" ? "active" : "")" for="radioSuccessBtn{@Step.Name}-@Step.Id">Success</label>
        
         <input type="radio"
-               checked="@( !IsStepSuccessful(LogStep) )"
+               checked="@(GetStepSuccessState(LogStep) == false)"
                autocomplete="off"
                @onclick="@(async (e) => await HandleButtonPress(false))"
                class="btn-check"
@@ -119,6 +119,9 @@
     
     private bool IsStepSuccessful(ProductionLogStep step) =>
         step.LatestAttempt?.Success == true;
+    
+    private bool? GetStepSuccessState(ProductionLogStep step) =>
+        step.LatestAttempt?.Success;
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -171,6 +171,18 @@
 
         SetOptionalNotes();
     }
+    
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        var latestSuccess = GetStepSuccessState(LogStep);
+        if (latestSuccess == true)
+            SelectedButton = "Success";
+        else if (latestSuccess == false)
+            SelectedButton = "Failure";
+        else
+            SelectedButton = ""; // or null
+    }
 
 
     private bool ShowDetails = false;

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -59,7 +59,7 @@
 <div class="row mt-3">
     <div class="col text-end">
         <input type="radio"
-               checked="@(LogStep.LatestAttempt?.Success == true)"
+               checked="@IsStepSuccessful(LogStep)"
                autocomplete="off"
                class="btn-check"
                name="radioBtn{@Step.Name}"
@@ -68,7 +68,7 @@
         <label class="btn btn-outline-success @(!string.IsNullOrEmpty(SelectedButton) && SelectedButton == "Success" ? "active" : "")" for="radioSuccessBtn{@Step.Name}-@Step.Id">Success</label>
        
         <input type="radio"
-               checked="@(LogStep.LatestAttempt?.Success == false)"
+               checked="@( !IsStepSuccessful(LogStep) )"
                autocomplete="off"
                @onclick="@(async (e) => await HandleButtonPress(false))"
                class="btn-check"
@@ -116,6 +116,9 @@
     private FluentTextArea? _failureNoteTextArea;
     
     private string _currentAttemptNotes = "";
+    
+    private bool IsStepSuccessful(ProductionLogStep step) =>
+        step.LatestAttempt?.Success == true;
 
     /// <inheritdoc />
     protected override void OnInitialized()

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -58,23 +58,48 @@
 </div>
 <div class="row mt-3">
     <div class="col text-end">
-        <input type="radio"
-               checked="@(GetStepSuccessState(LogStep) == true)"
-               autocomplete="off"
-               class="btn-check"
-               name="radioBtn{@Step.Name}"
-               id="radioSuccessBtn{@Step.Name}-@Step.Id"
-               @onclick="@(async (e) => await HandleButtonPress(true))"/>
-        <label class="btn btn-outline-success @(!string.IsNullOrEmpty(SelectedButton) && SelectedButton == "Success" ? "active" : "")" for="radioSuccessBtn{@Step.Name}-@Step.Id">Success</label>
-       
-        <input type="radio"
-               checked="@(GetStepSuccessState(LogStep) == false)"
-               autocomplete="off"
-               @onclick="@(async (e) => await HandleButtonPress(false))"
-               class="btn-check"
-               name="radioBtn{@Step.Name}"
-               id="radioFailureBtn{@Step.Name}-@Step.Id"/>
-        <label class="btn btn-outline-danger @(!string.IsNullOrEmpty(SelectedButton) && SelectedButton == "Failure" ? "active" : "")" for="radioFailureBtn{@Step.Name}-@Step.Id">Failure</label>
+        <div class="position-relative d-inline-block">
+            <!-- Success Button -->
+            <input type="radio"
+                   class="btn-check"
+                   name="statusToggle"
+                   id="radioSuccessBtn{@Step.Name}-@Step.Id"
+                   checked="@(SelectedButton == "Success")"
+                   @onclick="@(async (e) => await HandleButtonPress(true))" />
+            <label class="btn btn-outline-success @(SelectedButton == "Success" ? "active" : "")"
+                   for="radioSuccessBtn{@Step.Name}-@Step.Id">
+                Success
+            </label>
+
+            @if (_showSuccessFloat)
+            {
+                <div class="floating-label" style="left: 50%; transform: translateX(-50%);">
+                    Success!
+                </div>
+            }
+        </div>
+        
+        <div class="position-relative d-inline-block">
+            <!-- Failure Button -->
+            <input type="radio"
+                   class="btn-check"
+                   name="statusToggle"
+                   id="radioFailureBtn{@Step.Name}-@Step.Id"
+                   checked="@(SelectedButton == "Failure")"
+                   @onclick="@(async (e) => await HandleButtonPress(false))" />
+            <label class="btn btn-outline-danger @(SelectedButton == "Failure" ? "active" : "")"
+                   for="radioFailureBtn{@Step.Name}-@Step.Id">
+                Failure
+            </label>
+
+            @if (_showFailureFloat)
+            {
+                <div class="floating-label" style="left: 50%; transform: translateX(-50%); color: #dc3545;">
+                    Failure!
+                </div>
+            }
+        </div>
+
         
         <button @onclick="toggleDetails" class="btn btn-outline-secondary text-decoration-none" type="button">
             @(ShowDetails ? "Hide Details" : "Show Details")
@@ -124,6 +149,9 @@
     
     private bool? GetStepSuccessState(ProductionLogStep step) =>
         step.LatestAttempt?.Success;
+    
+    private bool _showSuccessFloat = false;
+    private bool _showFailureFloat = false;
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -159,7 +187,7 @@
 
     private void SetSelectedButton(string buttonName)
     {
-        SelectedButton = SelectedButton == buttonName ? null : buttonName;
+        SelectedButton = buttonName;
     }
     
     private void SetOptionalNotes()
@@ -199,6 +227,8 @@
 
             await OnStepCompleted.InvokeAsync((LogStep, true));
             SetSelectedButton("Success");
+            
+            await ShowFloatMessage(true);
         }
         else // FAILURE
         {
@@ -232,6 +262,8 @@
             {
                 await JsRuntime.InvokeVoidAsync("AutoFocus.setFocus", _failureNoteTextArea.Id);
             }
+            
+            await ShowFloatMessage(false);
         }
     }
     
@@ -242,5 +274,24 @@
             _pendingFailureAttempt.Notes = _currentAttemptNotes;
             await ProductionLogEventService.ChangeMadeToProductionLog();
         }
+    }
+    
+    private async Task ShowFloatMessage(bool isSuccess)
+    {
+        if (isSuccess)
+        {
+            _showSuccessFloat = true;
+            StateHasChanged();
+            await Task.Delay(800);
+            _showSuccessFloat = false;
+        }
+        else
+        {
+            _showFailureFloat = true;
+            StateHasChanged();
+            await Task.Delay(800);
+            _showFailureFloat = false;
+        }
+        StateHasChanged();
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -123,11 +123,11 @@
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        if (LogStep.LatestAttempt?.Success == null)
+        if (LogStep.LatestAttempt.Success == null)
         {
             SetSelectedButton("");
         }
-        else if (LogStep.LatestAttempt.Success.Value)
+        else if (IsStepSuccessful(LogStep))
         {
             SetSelectedButton("Success");
         }
@@ -135,9 +135,10 @@
         {
             SetSelectedButton("Failure");
         }
-    
+
         SetOptionalNotes();
     }
+
 
     private bool ShowDetails = false;
 

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -208,6 +208,7 @@
         if (!string.IsNullOrWhiteSpace(attempt.Notes) || 
             (attempt.Success.HasValue && !attempt.Success.Value))
         {
+            _currentAttemptNotes = LogStep.LatestAttempt.Notes;
             ShowOptionalNotesField = true;
         }
     }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -159,8 +159,9 @@
     
     private void SetOptionalNotes()
     {
-        if ((!string.IsNullOrWhiteSpace(LogStep.LatestAttempt.Notes) || 
-             (LogStep.LatestAttempt.Success.HasValue && !LogStep.LatestAttempt.Success.Value)))
+        var attempt = LogStep.LatestAttempt;
+        if (!string.IsNullOrWhiteSpace(attempt.Notes) || 
+            (attempt.Success.HasValue && !attempt.Success.Value))
         {
             ShowOptionalNotesField = true;
         }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -59,7 +59,7 @@
 <div class="row mt-3">
     <div class="col text-end">
         <input type="radio"
-               checked="@(LogStep.Success)"
+               checked="@(LogStep.LatestAttempt?.Success == true)"
                autocomplete="off"
                class="btn-check"
                name="radioBtn{@Step.Name}"
@@ -68,7 +68,7 @@
         <label class="btn btn-outline-success @(!string.IsNullOrEmpty(SelectedButton) && SelectedButton == "Success" ? "active" : "")" for="radioSuccessBtn{@Step.Name}-@Step.Id">Success</label>
        
         <input type="radio"
-               checked="@(!LogStep.Success)"
+               checked="@(LogStep.LatestAttempt?.Success == false)"
                autocomplete="off"
                @onclick="@(async (e) => await HandleButtonPress(false))"
                class="btn-check"
@@ -84,7 +84,12 @@
 
 
 <div class="d-inline-flex">
-    <FluentTextArea @ref="_failureNoteTextArea" data-testid="optional-notes" class="@(ShowOptionalNotesField ? "": "d-none" )" @bind-Value:after="@(async () => await ProductionLogEventService.ChangeMadeToProductionLog())" @bind-Value="LogStep.Notes"/>
+    <FluentTextArea 
+        @ref="_failureNoteTextArea" 
+        data-testid="optional-notes" 
+        class="@(ShowOptionalNotesField ? "" : "d-none")" 
+        @bind-Value="_currentAttemptNotes"
+        @bind-Value:after="@(async () => await ProductionLogEventService.ChangeMadeToProductionLog())" />
 </div>
 
 
@@ -109,21 +114,25 @@
     public EventCallback<(ProductionLogStep, bool?)> OnStepCompleted { get; set; }
 
     private FluentTextArea? _failureNoteTextArea;
+    
+    private string _currentAttemptNotes = "";
 
     /// <inheritdoc />
     protected override void OnInitialized()
     {
-        if (!LogStep.Success.HasValue)
+        if (LogStep.LatestAttempt?.Success == null)
         {
             SetSelectedButton("");
-        } else if (LogStep.Success.Value)
+        }
+        else if (LogStep.LatestAttempt.Success.Value)
         {
             SetSelectedButton("Success");
-        } else if (!LogStep.Success.Value)
+        }
+        else
         {
             SetSelectedButton("Failure");
         }
-        
+    
         SetOptionalNotes();
     }
 
@@ -146,7 +155,8 @@
     
     private void SetOptionalNotes()
     {
-        if (!string.IsNullOrWhiteSpace(LogStep.Notes) || (LogStep.Success.HasValue && !LogStep.Success.Value))
+        if ((!string.IsNullOrWhiteSpace(LogStep.LatestAttempt.Notes) || 
+             (LogStep.LatestAttempt.Success.HasValue && !LogStep.LatestAttempt.Success.Value)))
         {
             ShowOptionalNotesField = true;
         }
@@ -154,35 +164,37 @@
 
     private async Task HandleButtonPress(bool? result)
     {
-        if (SelectedButton == (result.HasValue ? (result.Value ? "Success" : "Failure") : ""))
+        var attempt = new ProductionLogStepAttempt()
         {
-            result = null;
-        }
-        
+            Success = result ?? false,
+            SubmitTime = DateTimeOffset.UtcNow,
+            Notes = (result.HasValue && !result.Value) ? _currentAttemptNotes : ""
+
+        };
+
+        LogStep.Attempts.Add(attempt);
+    
+        // Clear the temporary notes field
+        _currentAttemptNotes = string.Empty;
+    
+        await OnStepCompleted.InvokeAsync((LogStep, result));
+        SetSelectedButton(result.HasValue ? (result.Value ? "Success" : "Failure") : "");
+    
         if (!result.HasValue)
         {
             ShowOptionalNotesField = false;
-            await OnStepCompleted.InvokeAsync((LogStep, null));
-            SetSelectedButton("");
-            return;
         }
-        
-        if (!result.Value)
+        else if (!result.Value)
         {
             ShowOptionalNotesField = !ShowOptionalNotesField;
-            await OnStepCompleted.InvokeAsync((LogStep, false));
             if (ShowOptionalNotesField && _failureNoteTextArea?.Element != null)
             {
                 await JsRuntime.InvokeVoidAsync("AutoFocus.setFocus", _failureNoteTextArea.Id);
-                // _failureNoteTextArea.FocusAsync();
             }
         }
         else
         {
             ShowOptionalNotesField = false;
-            await OnStepCompleted.InvokeAsync((LogStep, true));
         }
-
-        SetSelectedButton(result.Value ? "Success" : "Failure");
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -89,7 +89,7 @@
         data-testid="optional-notes" 
         class="@(ShowOptionalNotesField ? "" : "d-none")" 
         @bind-Value="_currentAttemptNotes"
-        @bind-Value:after="@(async () => await ProductionLogEventService.ChangeMadeToProductionLog())" />
+        @bind-Value:after="@(async () => await HandleNoteChangedAsync())" />
 </div>
 
 
@@ -116,6 +116,8 @@
     private FluentTextArea? _failureNoteTextArea;
     
     private string _currentAttemptNotes = "";
+    
+    private ProductionLogStepAttempt? _pendingFailureAttempt;
     
     private bool IsStepSuccessful(ProductionLogStep step) =>
         step.LatestAttempt?.Success == true;
@@ -172,37 +174,73 @@
 
     private async Task HandleButtonPress(bool? result)
     {
-        var attempt = new ProductionLogStepAttempt()
-        {
-            Success = result ?? false,
-            SubmitTime = DateTimeOffset.UtcNow,
-            Notes = (result.HasValue && !result.Value) ? _currentAttemptNotes : ""
-
-        };
-
-        LogStep.Attempts.Add(attempt);
-    
-        // Clear the temporary notes field
-        _currentAttemptNotes = string.Empty;
-    
-        await OnStepCompleted.InvokeAsync((LogStep, result));
-        SetSelectedButton(result.HasValue ? (result.Value ? "Success" : "Failure") : "");
-    
         if (!result.HasValue)
         {
             ShowOptionalNotesField = false;
+            _pendingFailureAttempt = null;
+            _currentAttemptNotes = string.Empty;
+            SetSelectedButton("");
+            return;
         }
-        else if (!result.Value)
+
+        if (result.Value) // SUCCESS
         {
-            ShowOptionalNotesField = !ShowOptionalNotesField;
-            if (ShowOptionalNotesField && _failureNoteTextArea?.Element != null)
+            var attempt = new ProductionLogStepAttempt
+            {
+                Success = true,
+                SubmitTime = DateTimeOffset.UtcNow,
+                Notes = ""
+            };
+
+            LogStep.Attempts.Add(attempt);
+            _pendingFailureAttempt = null;
+            _currentAttemptNotes = string.Empty;
+            ShowOptionalNotesField = false;
+
+            await OnStepCompleted.InvokeAsync((LogStep, true));
+            SetSelectedButton("Success");
+        }
+        else // FAILURE
+        {
+            // If there's already a pending failure, finalize it by setting its notes
+            if (_pendingFailureAttempt != null)
+            {
+                _pendingFailureAttempt.Notes = _currentAttemptNotes;
+                _pendingFailureAttempt = null;
+            }
+
+            // Clear input for the next note
+            _currentAttemptNotes = string.Empty;
+
+            // Create new pending attempt
+            _pendingFailureAttempt = new ProductionLogStepAttempt
+            {
+                Success = false,
+                SubmitTime = DateTimeOffset.UtcNow,
+                Notes = ""
+            };
+            LogStep.Attempts.Add(_pendingFailureAttempt);
+
+            ShowOptionalNotesField = true;
+            SetSelectedButton("Failure");
+
+            await OnStepCompleted.InvokeAsync((LogStep, false));
+            StateHasChanged();
+            await Task.Yield();
+
+            if (_failureNoteTextArea?.Element != null)
             {
                 await JsRuntime.InvokeVoidAsync("AutoFocus.setFocus", _failureNoteTextArea.Id);
             }
         }
-        else
+    }
+    
+    private async Task HandleNoteChangedAsync()
+    {
+        if (_pendingFailureAttempt != null)
         {
-            ShowOptionalNotesField = false;
+            _pendingFailureAttempt.Notes = _currentAttemptNotes;
+            await ProductionLogEventService.ChangeMadeToProductionLog();
         }
     }
 }

--- a/MESS/MESS.Blazor/Program.cs
+++ b/MESS/MESS.Blazor/Program.cs
@@ -24,12 +24,15 @@ builder.Services.AddDbContextFactory<ApplicationContext>(options =>
 {
     var connectionString = builder.Configuration.GetConnectionString("MESSConnection");
 
-    options.UseSqlServer(connectionString, options =>
+    options.UseSqlServer(connectionString, sqlOptions =>
     {
-        options.EnableRetryOnFailure(
+        sqlOptions.EnableRetryOnFailure(
             maxRetryCount: 3,
             maxRetryDelay: TimeSpan.FromSeconds(30),
             errorNumbersToAdd: null);
+
+        // Use split queries to avoid Cartesian explosion when loading multiple collections
+        sqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
     });
 });
 

--- a/MESS/MESS.Blazor/wwwroot/app.css
+++ b/MESS/MESS.Blazor/wwwroot/app.css
@@ -277,3 +277,23 @@ td {
 .carousel-control-next:hover {
     opacity: 0.8;              /* Slight dimming on hover for interactivity */
 }
+
+@keyframes floatAway {
+    0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(-40px) scale(1.2);
+    }
+}
+
+.floating-label {
+    position: absolute;
+    font-weight: bold;
+    pointer-events: none;
+    animation: floatAway 0.8s ease-out forwards;
+    color: #28a745; /* success green or change for failure */
+}
+

--- a/MESS/MESS.Data/Context/ApplicationContext.cs
+++ b/MESS/MESS.Data/Context/ApplicationContext.cs
@@ -41,6 +41,17 @@ public class ApplicationContext : DbContext
     /// DbSet for ProductionLogs.
     /// </summary>
     public virtual DbSet<ProductionLog> ProductionLogs { get; set; } = null!;
+    
+    /// <summary>
+    /// DbSet for ProductionLogSteps.
+    /// </summary>
+    public virtual DbSet<ProductionLogStep> ProductionLogSteps { get; set; } = null!;
+
+    /// <summary>
+    /// DbSet for ProductionLogStepAttempts.
+    /// </summary>
+    public virtual DbSet<ProductionLogStepAttempt> ProductionLogStepAttempts { get; set; } = null!;
+    
     /// <summary>
     /// DbSet for Products.
     /// </summary>
@@ -67,11 +78,36 @@ public class ApplicationContext : DbContext
         modelBuilder.Entity<Step>()
             .ToTable("Steps");
         
-        modelBuilder.Entity<ProductionLog>()
-            .HasOne(p => p.WorkInstruction)
-            .WithMany()
-            .HasForeignKey("WorkInstructionId")
-            .IsRequired(false);
+        modelBuilder.Entity<ProductionLog>(entity =>
+        {
+            // Configure WorkInstruction relationship
+            entity.HasOne(p => p.WorkInstruction)
+                .WithMany()
+                .HasForeignKey("WorkInstructionId")
+                .IsRequired(false);
+    
+            // Configure LogSteps relationship
+            entity.HasMany(p => p.LogSteps)
+                .WithOne(s => s.ProductionLog)
+                .HasForeignKey(s => s.ProductionLogId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+
+        modelBuilder.Entity<ProductionLogStep>(entity =>
+        {
+            // Relationship to attempts
+            entity.HasMany(s => s.Attempts)
+                .WithOne(a => a.ProductionLogStep)
+                .HasForeignKey(a => a.ProductionLogStepId)
+                .OnDelete(DeleteBehavior.Cascade);
+    
+            // Relationship to work instruction step
+            entity.HasOne(s => s.WorkInstructionStep)
+                .WithMany()
+                .HasForeignKey(s => s.WorkInstructionStepId);
+            
+        });
     }
     
     /// <inheritdoc />

--- a/MESS/MESS.Data/Context/DesignTimeDbContextFactory.cs
+++ b/MESS/MESS.Data/Context/DesignTimeDbContextFactory.cs
@@ -22,7 +22,7 @@ namespace MESS.Data.Context
             var configuration = new ConfigurationBuilder()
                 .SetBasePath(basePath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddUserSecrets("135263b1-164f-4c79-9970-4a2d72396135") // <-- This line adds user secrets
+                .AddUserSecrets<ApplicationContextFactory>() // <-- This line adds user secrets
                 .Build();
 
             var optionsBuilder = new DbContextOptionsBuilder<ApplicationContext>();

--- a/MESS/MESS.Data/Context/DesignTimeDbContextFactory.cs
+++ b/MESS/MESS.Data/Context/DesignTimeDbContextFactory.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System.IO;
+
+namespace MESS.Data.Context
+{
+    /// <summary>
+    /// Used to create a design time DbContext to run migrations via shell
+    /// </summary>
+    public class ApplicationContextFactory : IDesignTimeDbContextFactory<ApplicationContext>
+    {
+        /// <summary>
+        /// Creates the design time DbContext
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public ApplicationContext CreateDbContext(string[] args)
+        {
+            var basePath = Directory.GetCurrentDirectory();
+            
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(basePath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddUserSecrets("135263b1-164f-4c79-9970-4a2d72396135") // <-- This line adds user secrets
+                .Build();
+
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationContext>();
+            var connectionString = configuration.GetConnectionString("MESSConnection");
+
+            optionsBuilder.UseSqlServer(connectionString, options =>
+            {
+                options.EnableRetryOnFailure(
+                    maxRetryCount: 3,
+                    maxRetryDelay: TimeSpan.FromSeconds(30),
+                    errorNumbersToAdd: null);
+            });
+
+            return new ApplicationContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/MESS/MESS.Data/DTO/ProductionLogStepAttemptDTO.cs
+++ b/MESS/MESS.Data/DTO/ProductionLogStepAttemptDTO.cs
@@ -1,0 +1,23 @@
+namespace MESS.Data.DTO;
+
+
+/// <summary>
+/// Represents an individual attempt at completing a production log step.
+/// </summary>
+public class ProductionLogStepAttemptDTO
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the attempt was successful.
+    /// </summary>
+    public bool? Success { get; set; }
+
+    /// <summary>
+    /// Gets or sets the time the attempt was submitted.
+    /// </summary>
+    public DateTimeOffset SubmitTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets the notes associated with this specific attempt.
+    /// </summary>
+    public string? Notes { get; set; }
+}

--- a/MESS/MESS.Data/DTO/ProductionLogStepDTO.cs
+++ b/MESS/MESS.Data/DTO/ProductionLogStepDTO.cs
@@ -4,6 +4,7 @@ namespace MESS.Data.DTO;
 
 /// <summary>
 /// Represents a step in the production log. Used primarily for client-side caching purposes.
+/// Now supports multiple attempts per step.
 /// </summary>
 public class ProductionLogStepDTO
 {
@@ -18,22 +19,12 @@ public class ProductionLogStepDTO
     public int ProductionLogId { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the step was successful.
+    /// Gets or sets the collection of attempts for this step.
     /// </summary>
-    public bool? Success { get; set; }
-
-    /// <summary>
-    /// Gets or sets the time the step was submitted.
-    /// </summary>
-    public DateTimeOffset SubmitTime { get; set; }
+    public List<ProductionLogStepAttemptDTO> Attempts { get; set; } = new();
 
     /// <summary>
     /// Gets or sets a value indicating whether to show notes for the step.
     /// </summary>
     public bool ShowNotes { get; set; }
-
-    /// <summary>
-    /// Gets or sets the notes associated with the step.
-    /// </summary>
-    public string? Notes { get; set; }
 }

--- a/MESS/MESS.Data/MESS.Data.csproj
+++ b/MESS/MESS.Data/MESS.Data.csproj
@@ -30,6 +30,8 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.5.25277.114" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0-preview.5.25277.114" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
       <PackageReference Include="Serilog" Version="4.2.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />

--- a/MESS/MESS.Data/MESS.Data.csproj
+++ b/MESS/MESS.Data/MESS.Data.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <UserSecretsId>4cf3f9ba-9590-456a-85a7-ac170a6f7d71</UserSecretsId>
+        <UserSecretsId>135263b1-164f-4c79-9970-4a2d72396135</UserSecretsId>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 

--- a/MESS/MESS.Data/Migrations/20250616193002_ConvertToStepAttempts.Designer.cs
+++ b/MESS/MESS.Data/Migrations/20250616193002_ConvertToStepAttempts.Designer.cs
@@ -4,6 +4,7 @@ using MESS.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MESS.Data.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20250616193002_ConvertToStepAttempts")]
+    partial class ConvertToStepAttempts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MESS/MESS.Data/Migrations/20250616193002_ConvertToStepAttempts.cs
+++ b/MESS/MESS.Data/Migrations/20250616193002_ConvertToStepAttempts.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MESS.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ConvertToStepAttempts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProductionLogStep_ProductionLogs_ProductionLogId",
+                table: "ProductionLogStep");
+
+            // migrationBuilder.DropForeignKey(
+                // name: "FK_ProductionLogStep_Steps_WorkInstructionStepId",
+                // table: "ProductionLogStep");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProductionLogStep",
+                table: "ProductionLogStep");
+
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "ProductionLogStep");
+
+            migrationBuilder.DropColumn(
+                name: "SubmitTime",
+                table: "ProductionLogStep");
+
+            migrationBuilder.DropColumn(
+                name: "Success",
+                table: "ProductionLogStep");
+
+            migrationBuilder.RenameTable(
+                name: "ProductionLogStep",
+                newName: "ProductionLogSteps");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ProductionLogStep_WorkInstructionStepId",
+                table: "ProductionLogSteps",
+                newName: "IX_ProductionLogSteps_WorkInstructionStepId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ProductionLogStep_ProductionLogId",
+                table: "ProductionLogSteps",
+                newName: "IX_ProductionLogSteps_ProductionLogId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProductionLogSteps",
+                table: "ProductionLogSteps",
+                column: "Id");
+
+            migrationBuilder.CreateTable(
+                name: "ProductionLogStepAttempts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ProductionLogStepId = table.Column<int>(type: "int", nullable: false),
+                    Success = table.Column<bool>(type: "bit", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    SubmitTime = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProductionLogStepAttempts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProductionLogStepAttempts_ProductionLogSteps_ProductionLogStepId",
+                        column: x => x.ProductionLogStepId,
+                        principalTable: "ProductionLogSteps",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductionLogStepAttempts_ProductionLogStepId",
+                table: "ProductionLogStepAttempts",
+                column: "ProductionLogStepId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProductionLogSteps_ProductionLogs_ProductionLogId",
+                table: "ProductionLogSteps",
+                column: "ProductionLogId",
+                principalTable: "ProductionLogs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProductionLogSteps_Steps_WorkInstructionStepId",
+                table: "ProductionLogSteps",
+                column: "WorkInstructionStepId",
+                principalTable: "Steps",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProductionLogSteps_ProductionLogs_ProductionLogId",
+                table: "ProductionLogSteps");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ProductionLogSteps_Steps_WorkInstructionStepId",
+                table: "ProductionLogSteps");
+
+            migrationBuilder.DropTable(
+                name: "ProductionLogStepAttempts");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ProductionLogSteps",
+                table: "ProductionLogSteps");
+
+            migrationBuilder.RenameTable(
+                name: "ProductionLogSteps",
+                newName: "ProductionLogStep");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ProductionLogSteps_WorkInstructionStepId",
+                table: "ProductionLogStep",
+                newName: "IX_ProductionLogStep_WorkInstructionStepId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ProductionLogSteps_ProductionLogId",
+                table: "ProductionLogStep",
+                newName: "IX_ProductionLogStep_ProductionLogId");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "ProductionLogStep",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SubmitTime",
+                table: "ProductionLogStep",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Success",
+                table: "ProductionLogStep",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ProductionLogStep",
+                table: "ProductionLogStep",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProductionLogStep_ProductionLogs_ProductionLogId",
+                table: "ProductionLogStep",
+                column: "ProductionLogId",
+                principalTable: "ProductionLogs",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ProductionLogStep_Steps_WorkInstructionStepId",
+                table: "ProductionLogStep",
+                column: "WorkInstructionStepId",
+                principalTable: "Steps",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/MESS/MESS.Data/Models/ProductionLogStep.cs
+++ b/MESS/MESS.Data/Models/ProductionLogStep.cs
@@ -17,29 +17,32 @@ public class ProductionLogStep
     /// Gets or sets the identifier of the associated production log.
     /// </summary>
     public int ProductionLogId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the associated ProductionLog
+    /// </summary>
+    public ProductionLog? ProductionLog { get; set; }
 
     /// <summary>
     /// Gets or sets the identifier of the associated work instruction step.
     /// </summary>
     public int WorkInstructionStepId { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the step was successful.
-    /// </summary>
-    public bool? Success { get; set; } = null;
-
-    /// <summary>
-    /// Gets or sets any additional notes for the step.
-    /// </summary>
-    public string Notes { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the time the step was submitted.
-    /// </summary>
-    public DateTimeOffset SubmitTime { get; set; }
-
+    
     /// <summary>
     /// Gets or sets the associated work instruction step details.
     /// </summary>
     public Step? WorkInstructionStep { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the collection of attempts for this step
+    /// </summary>
+    public List<ProductionLogStepAttempt> Attempts { get; set; } = new();
+    
+    /// <summary>
+    /// Helper property to get the most recent attempt
+    /// </summary>
+    public ProductionLogStepAttempt LatestAttempt => 
+        Attempts.OrderByDescending(a => a.SubmitTime).FirstOrDefault() 
+        ?? new ProductionLogStepAttempt { Success = null };
+
 }

--- a/MESS/MESS.Data/Models/ProductionLogStepAttempt.cs
+++ b/MESS/MESS.Data/Models/ProductionLogStepAttempt.cs
@@ -1,0 +1,39 @@
+namespace MESS.Data.Models;
+
+/// <summary>
+/// Represents an attempt for a step in the production log. One step can have multiple of these.
+/// Similar to the <see cref="Step"/> but is used to persist the data within the database.
+/// </summary>
+public class ProductionLogStepAttempt
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the production log step attempt.
+    /// </summary>
+    public int Id { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the identifier of the associated production log step.
+    /// </summary>
+    public int ProductionLogStepId { get; set; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the step attempt was successful.
+    /// </summary>
+    public bool? Success { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets any additional notes for the step attempt.
+    /// </summary>
+    public string Notes { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the time the step attempt occured.
+    /// </summary>
+    public DateTimeOffset SubmitTime { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the associated production log step
+    /// </summary>
+    public ProductionLogStep? ProductionLogStep { get; set; }
+    
+}

--- a/MESS/MESS.Services/LocalCacheManager/LocalCacheManager.cs
+++ b/MESS/MESS.Services/LocalCacheManager/LocalCacheManager.cs
@@ -40,7 +40,20 @@ public class LocalCacheManager : ILocalCacheManager
 
             Log.Information("Successfully Set New Production Log Form with ID: {PLogID}", productionLog.Id);
             var productionLogForm = MapProductionLogToDto(productionLog);
-            await _protectedLocalStorage.SetAsync(PRODUCTION_LOG_FORM_KEY, productionLogForm);
+            
+            try
+            {
+                await _protectedLocalStorage.SetAsync(PRODUCTION_LOG_FORM_KEY, productionLogForm);
+            }
+            catch (TaskCanceledException ex)
+            {
+                Log.Warning("SetNewProductionLogFormAsync was canceled. The app may have been navigating or busy. Exception: {Exception}", ex);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Unexpected error while setting ProductionLogForm in local storage: {Exception}", ex);
+            }
+            
         }
         catch (Exception e)
         {

--- a/MESS/MESS.Services/LocalCacheManager/LocalCacheManager.cs
+++ b/MESS/MESS.Services/LocalCacheManager/LocalCacheManager.cs
@@ -51,21 +51,28 @@ public class LocalCacheManager : ILocalCacheManager
     private static ProductionLogFormDTO MapProductionLogToDto(ProductionLog productionLog)
     {
         var productionLogFormDto = new ProductionLogFormDTO();
+    
         foreach (var step in productionLog.LogSteps)
         {
-            productionLogFormDto.LogSteps.Add(new ProductionLogStepDTO
+            var stepDto = new ProductionLogStepDTO
             {
                 WorkInstructionStepId = step.WorkInstructionStepId,
                 ProductionLogId = step.ProductionLogId,
-                Success = step.Success,
-                SubmitTime = step.SubmitTime,
-                Notes = step.Notes,
-                ShowNotes = step.Notes.Length > 0,
-            });
+                ShowNotes = step.Attempts.Any(a => !string.IsNullOrEmpty(a.Notes))
+            };
+
+            // Map all attempts
+            stepDto.Attempts = step.Attempts.Select(a => new ProductionLogStepAttemptDTO
+            {
+                Success = a.Success,
+                SubmitTime = a.SubmitTime,
+                Notes = a.Notes,
+            }).ToList();
+
+            productionLogFormDto.LogSteps.Add(stepDto);
         }
 
         productionLogFormDto.ProductionLogId = productionLog.Id;
-
         return productionLogFormDto;
     }
 

--- a/MESS/MESS.Services/ProductionLog/ProductionLogService.cs
+++ b/MESS/MESS.Services/ProductionLog/ProductionLogService.cs
@@ -92,64 +92,45 @@ public class ProductionLogService : IProductionLogService
         try
         {
             await using var context = await _contextFactory.CreateDbContextAsync();
+            
 
-            // Mark existing Product as Unchanged
+
             if (productionLog.Product is { Id: > 0 })
             {
                 context.Entry(productionLog.Product).State = EntityState.Unchanged;
             }
-
-            // Mark WorkInstruction and its Nodes as Unchanged
+            
             if (productionLog.WorkInstruction is { Id: > 0 })
             {
                 context.Entry(productionLog.WorkInstruction).State = EntityState.Unchanged;
-
-                foreach (var node in productionLog.WorkInstruction.Nodes.Where(n => n.Id > 0))
+                
+                foreach (var node in productionLog.WorkInstruction.Nodes.Where(node => node.Id > 0))
                 {
                     context.Entry(node).State = EntityState.Unchanged;
                 }
             }
-
-            // For each LogStep
-            if (productionLog.LogSteps is { Count: > 0 })
-            {
-                foreach (var step in productionLog.LogSteps)
-                {
-                    // Remove any EF-tracked reference and use only the FK
-                    if (step.WorkInstructionStep is { Id: > 0 })
-                    {
-                        context.Entry(step.WorkInstructionStep).State = EntityState.Unchanged;
-                    }
-
-                    // Avoid attaching navigation property directly if possible
-                    step.WorkInstructionStep = null; // prevent EF from trying to insert it again
-                }
-            }
-
+            
             productionLog.CreatedOn = DateTimeOffset.UtcNow;
             productionLog.LastModifiedOn = DateTimeOffset.UtcNow;
             
-            // Debug safeguard to catch bad entity states
-            foreach (var entry in context.ChangeTracker.Entries())
-            {
-                if (entry.State == EntityState.Added && entry.Metadata.FindPrimaryKey() != null)
-                {
-                    var idProperty = entry.Properties.FirstOrDefault(p =>
-                        string.Equals(p.Metadata.Name, "Id", StringComparison.OrdinalIgnoreCase));
-
-                    if (idProperty?.CurrentValue is int id && id > 0)
-                    {
-                        Log.Warning("⚠️ Entity of type {EntityType} is in Added state but has existing ID: {Id}",
-                            entry.Entity.GetType().Name, id);
-                    }
-                }
-            }
-            
-            // Save the ProductionLog (with FK references only)
             await context.ProductionLogs.AddAsync(productionLog);
             await context.SaveChangesAsync();
 
+            if (productionLog.LogSteps is {Count: > 0})
+            {
+                foreach (var logStep in productionLog.LogSteps)
+                {
+                    logStep.ProductionLogId = productionLog.Id;
+                    if (logStep.WorkInstructionStep is { Id: > 0 })
+                    {
+                        context.Entry(logStep.WorkInstructionStep).State = EntityState.Unchanged;
+                    }
+                }
+                await context.SaveChangesAsync();
+            }
+            
             Log.Information("Successfully created Production Log with ID: {productionLogID}", productionLog.Id);
+            
             return productionLog.Id;
         }
         catch (Exception e)
@@ -158,7 +139,7 @@ public class ProductionLogService : IProductionLogService
             return -1;
         }
     }
-    
+
     /// <inheritdoc />
     public async Task<List<ProductionLog>?> GetProductionLogsByListOfIdsAsync(List<int> logIds)
     {

--- a/MESS/MESS.Services/ProductionLog/ProductionLogService.cs
+++ b/MESS/MESS.Services/ProductionLog/ProductionLogService.cs
@@ -92,45 +92,64 @@ public class ProductionLogService : IProductionLogService
         try
         {
             await using var context = await _contextFactory.CreateDbContextAsync();
-            
 
-
+            // Mark existing Product as Unchanged
             if (productionLog.Product is { Id: > 0 })
             {
                 context.Entry(productionLog.Product).State = EntityState.Unchanged;
             }
-            
+
+            // Mark WorkInstruction and its Nodes as Unchanged
             if (productionLog.WorkInstruction is { Id: > 0 })
             {
                 context.Entry(productionLog.WorkInstruction).State = EntityState.Unchanged;
-                
-                foreach (var node in productionLog.WorkInstruction.Nodes.Where(node => node.Id > 0))
+
+                foreach (var node in productionLog.WorkInstruction.Nodes.Where(n => n.Id > 0))
                 {
                     context.Entry(node).State = EntityState.Unchanged;
                 }
             }
-            
+
+            // For each LogStep
+            if (productionLog.LogSteps is { Count: > 0 })
+            {
+                foreach (var step in productionLog.LogSteps)
+                {
+                    // Remove any EF-tracked reference and use only the FK
+                    if (step.WorkInstructionStep is { Id: > 0 })
+                    {
+                        context.Entry(step.WorkInstructionStep).State = EntityState.Unchanged;
+                    }
+
+                    // Avoid attaching navigation property directly if possible
+                    step.WorkInstructionStep = null; // prevent EF from trying to insert it again
+                }
+            }
+
             productionLog.CreatedOn = DateTimeOffset.UtcNow;
             productionLog.LastModifiedOn = DateTimeOffset.UtcNow;
             
+            // Debug safeguard to catch bad entity states
+            foreach (var entry in context.ChangeTracker.Entries())
+            {
+                if (entry.State == EntityState.Added && entry.Metadata.FindPrimaryKey() != null)
+                {
+                    var idProperty = entry.Properties.FirstOrDefault(p =>
+                        string.Equals(p.Metadata.Name, "Id", StringComparison.OrdinalIgnoreCase));
+
+                    if (idProperty?.CurrentValue is int id && id > 0)
+                    {
+                        Log.Warning("⚠️ Entity of type {EntityType} is in Added state but has existing ID: {Id}",
+                            entry.Entity.GetType().Name, id);
+                    }
+                }
+            }
+            
+            // Save the ProductionLog (with FK references only)
             await context.ProductionLogs.AddAsync(productionLog);
             await context.SaveChangesAsync();
 
-            if (productionLog.LogSteps is {Count: > 0})
-            {
-                foreach (var logStep in productionLog.LogSteps)
-                {
-                    logStep.ProductionLogId = productionLog.Id;
-                    if (logStep.WorkInstructionStep is { Id: > 0 })
-                    {
-                        context.Entry(logStep.WorkInstructionStep).State = EntityState.Unchanged;
-                    }
-                }
-                await context.SaveChangesAsync();
-            }
-            
             Log.Information("Successfully created Production Log with ID: {productionLogID}", productionLog.Id);
-            
             return productionLog.Id;
         }
         catch (Exception e)
@@ -139,7 +158,7 @@ public class ProductionLogService : IProductionLogService
             return -1;
         }
     }
-
+    
     /// <inheritdoc />
     public async Task<List<ProductionLog>?> GetProductionLogsByListOfIdsAsync(List<int> logIds)
     {

--- a/MESS/MESS.Services/WorkInstruction/WorkInstructionService.cs
+++ b/MESS/MESS.Services/WorkInstruction/WorkInstructionService.cs
@@ -42,8 +42,8 @@ public partial class WorkInstructionService : IWorkInstructionService
     private const string WORK_INSTRUCTION_IMAGES_DIRECTORY = "WorkInstructionImages";
     const string WORK_INSTRUCTION_CACHE_KEY = "AllWorkInstructions";
 
-    // Currently, this is set to 500MB
-    private const int SPREADSHEET_SIZE_LIMIT = 500 * 1024 * 1024;
+    // Currently, this is set to 1GB
+    private const int SPREADSHEET_SIZE_LIMIT = 1024 * 1024 * 1024;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WorkInstructionService"/> class.


### PR DESCRIPTION
This pull request adds support for a given work instruction step to have multiple attempts within a production log. This was achieved by adding a new production log step attempts table to the database. Now, each production log step attempt has reference to a production log step. A given attempt can be either success or failure. Each attempt can also store its own failure note and has its own submit time.

This pull request also fixes a long standing bug in MESS where a production log submitted after changing work instruction would not be submitted. Visual effects have also been added to the success and failure buttons and the spreadsheet size limit has again been increased. 