### PR TITLE
security changes to dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,11 +9,17 @@ on:
     paths: # Only runs when a file ending in .cs or .csproj is changed
     - '**.cs'
     - '**.csproj'
+    - '**.cshtml'
+    - '**.razor'
+    - '**.js'
   pull_request:
     branches: [ "main" ]
     paths:
     - '**.cs'
     - '**.csproj'
+    - '**.cshtml'
+    - '**.razor'
+    - '**.js'
     
 env:
   DOTNET_VERSION: '9.0.200' # Current as of 4/16/2025


### PR DESCRIPTION
changed dotnet.yml to run on changes to these types of files:
    - '**.cs'
    - '**.csproj'
    - '**.cshtml'
    - '**.razor'
    - '**.js'