### PR TITLE
More Product UI Improvements

### DIFF
--- a/MESS/MESS.Blazor/Components/ConfirmationDialog/ConfirmationDialog.razor
+++ b/MESS/MESS.Blazor/Components/ConfirmationDialog/ConfirmationDialog.razor
@@ -1,0 +1,81 @@
+@if (Visible)
+{
+    <FluentDialog Open="@Visible" OnDismiss="OnCancelClicked">
+        <FluentDialogHeader>
+            <h5 class="fw-semibold text-dark mb-1">@Title</h5>
+            <FluentDivider></FluentDivider>
+        </FluentDialogHeader>
+        <FluentDialogBody>
+            <p>@Message</p>
+        </FluentDialogBody>
+        <FluentDialogFooter>
+            <button type="button" class="btn btn-sm btn-primary" @onclick="OnConfirmClicked" disabled="@IsProcessing">
+                @if (IsProcessing)
+                {
+                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                    <span> Processing...</span>
+                }
+                else
+                {
+                    <span>@ConfirmButtonText</span>
+                }
+            </button>
+            <button type="button" class="btn btn-sm btn-outline-secondary" @onclick="OnCancelClicked" disabled="@IsProcessing">
+                Cancel
+            </button>
+        </FluentDialogFooter>
+    </FluentDialog>
+}
+
+@code {
+    /// <summary>
+    /// Title of the dialog.
+    /// </summary>
+    [Parameter] public string Title { get; set; } = "Please Confirm";
+
+    /// <summary>
+    /// Confirmation message.
+    /// </summary>
+    [Parameter, EditorRequired] public string Message { get; set; } = "Are you sure?";
+
+    /// <summary>
+    /// Text of the confirm button.
+    /// </summary>
+    [Parameter] public string ConfirmButtonText { get; set; } = "Confirm";
+
+    /// <summary>
+    /// Controls whether the dialog is visible.
+    /// </summary>
+    [Parameter] public bool Visible { get; set; }
+
+    /// <summary>
+    /// Event callback invoked when Visible changes (two-way binding).
+    /// </summary>
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+
+    /// <summary>
+    /// Event callback invoked when the user confirms the action.
+    /// </summary>
+    [Parameter] public EventCallback OnConfirmed { get; set; }
+
+    private bool IsProcessing { get; set; }
+
+    private async Task OnConfirmClicked()
+    {
+        IsProcessing = true;
+        await OnConfirmed.InvokeAsync();
+        IsProcessing = false;
+        await CloseAsync();
+    }
+
+    private async Task OnCancelClicked()
+    {
+        await CloseAsync();
+    }
+
+    private async Task CloseAsync()
+    {
+        Visible = false;
+        await VisibleChanged.InvokeAsync(Visible);
+    }
+}

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
@@ -38,13 +38,14 @@ else
             <ProductTableRow 
                 Product="product" 
                 Instructions="_associatedInstructionsMap.ContainsKey(product.Id) 
-                ? _associatedInstructionsMap[product.Id] 
-                : new List<WorkInstruction>()"
+                    ? _associatedInstructionsMap[product.Id] 
+                    : new List<WorkInstruction>()"
                 SelectedInstructionIds="GetSelectedIds(product.Id)"
                 SelectedInstructionIdsChanged="@GetSelectedIdsChangedCallback(product.Id)"
                 OnAddInstructions="@GetAddInstructionsCallback(product.Id)"
                 OnRemoveInstructions="@GetRemoveInstructionsCallback(product.Id)"
-                OnSubmit="@SubmitProductCallback" />
+                OnSubmit="@SubmitProductCallback"
+                OnDeleteRequested="@HandleDeleteProductAsync" />
         }
 
         <ProductTableRow 
@@ -227,5 +228,24 @@ else
         _allInstructions = await WorkInstructionService.GetAllLatestAsync();
         RebuildInstructionMap();
         ToastService.ShowSuccess("Selected work instructions removed.");
+    }
+    
+    private async Task HandleDeleteProductAsync(Product product)
+    {
+        try
+        {
+            await ProductService.DeleteByIdAsync(product.Id);
+            Products.Remove(product);
+            _associatedInstructionsMap.Remove(product.Id);
+            SelectedInstructionMap.Remove(product.Id);
+            _selectedIdsChangedCallbacks.Remove(product.Id);
+
+            ToastService.ShowSuccess($"Product '{product.Name}' was deleted.");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error deleting product: {ProductName} (ID: {ProductId})", product.Name, product.Id);
+            ToastService.ShowError($"Failed to delete '{product.Name}'.");
+        }
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
@@ -71,7 +71,7 @@ else
     private Product _newProduct = new() { Name = "", IsActive = true };
     private List<WorkInstruction>? _allInstructions;
     private Dictionary<int, List<int>> SelectedInstructionMap { get; set; } = new();
-    private Dictionary<int, EventCallback<List<int>>> _selectedIdsChangedCallbacks = new();
+    private readonly Dictionary<int, EventCallback<List<int>>> _selectedIdsChangedCallbacks = new();
     private Dictionary<int, List<WorkInstruction>> _associatedInstructionsMap = new();
 
     private bool _addDialogVisible = false;

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
@@ -28,6 +28,7 @@ else
             <tr>
                 <th>Name</th>
                 <th>Active</th>
+                <th></th>
                 <th>Work Instructions</th>
                 <th>Actions</th>
             </tr>

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor
@@ -4,10 +4,28 @@
 
 <tr>
     <td>
-        <InputText id="name" @bind-Value="Product.Name" class="form-control" placeholder="Enter product name" />
+        <InputText id="name" @bind-Value="Product.Name" class="form-control" placeholder="Enter product name" @oninput="OnInputChanged"/>
     </td>
     <td>
-        <InputCheckbox id="isActive" @bind-Value="Product.IsActive" class="form-check-input" />
+        <InputCheckbox id="isActive"
+                       Value="Product.IsActive"
+                       ValueChanged="HandleCheckboxChanged"
+                       ValueExpression="() => Product.IsActive"
+                       class="form-check-input" />
+    </td>
+    <td>
+        @if (!IsNewProduct)
+        {
+            <div class="save-button-container">
+                <button class="btn btn-sm btn-success" @onclick="HandleSubmit" disabled="@isSaving" title="Save">
+                    <i class="bi bi-floppy"></i>
+                    @if (IsDirty)
+                    {
+                        <span class="red-dot"></span>
+                    }
+                </button>
+            </div>
+        }
     </td>
     <td>
         <WorkInstructionSelector 
@@ -18,15 +36,10 @@
             OnRemoveSelected="OnRemoveInstructions" />
     </td>
     <td>
-        <button class="btn btn-sm @(IsNewProduct ? "btn-primary" : "btn-success")"
-                @onclick="HandleSubmit" disabled="@isSaving">
-            @(IsNewProduct ? "Create" : "Save")
-        </button>
-        
         @if (!IsNewProduct)
         {
             <button class="btn btn-sm btn-danger ms-2" @onclick="ShowDeleteConfirmation">
-                Delete
+                <i class="bi bi-trash" />
             </button>
 
             <ConfirmationDialog
@@ -36,6 +49,12 @@
                 Visible="@showDeleteDialog"
                 VisibleChanged="@DeleteDialogVisibilityChanged"
                 OnConfirmed="RaiseDeleteEvent" />
+        }
+        else
+        {
+            <button class="btn btn-sm btn-primary" @onclick="HandleSubmit" disabled="@isSaving">
+                <i class="bi bi-plus-lg"></i>
+            </button>
         }
     </td>
 </tr>
@@ -95,14 +114,24 @@
 
     private bool IsNewProduct => Product.Id == 0;
     private bool isSaving = false;
+    private bool IsDirty { get; set; } = false;
     
     private bool showDeleteDialog;
+    
+    private void OnInputChanged(ChangeEventArgs e)
+    {
+        IsDirty = true;
+    }
 
     private async Task HandleSubmit()
     {
+        if (!IsDirty)
+            return;
+
         isSaving = true;
         await OnSubmit.InvokeAsync(Product);
         isSaving = false;
+        IsDirty = false;
     }
     
     private void ShowDeleteConfirmation()
@@ -118,5 +147,11 @@
     private void SetDeleteDialogVisibility(bool visible)
     {
         showDeleteDialog = visible;
+    }
+    
+    private void HandleCheckboxChanged(bool newValue)
+    {
+        Product.IsActive = newValue;
+        IsDirty = true;
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor
@@ -1,5 +1,6 @@
 @using MESS.Data.Models
 @using MESS.Blazor.Components.Pages.Phoebe.Product.ProductTableRow.WorkInstructionAssociation
+@using MESS.Blazor.Components.ConfirmationDialog
 
 <tr>
     <td>
@@ -21,6 +22,21 @@
                 @onclick="HandleSubmit" disabled="@isSaving">
             @(IsNewProduct ? "Create" : "Save")
         </button>
+        
+        @if (!IsNewProduct)
+        {
+            <button class="btn btn-sm btn-danger ms-2" @onclick="ShowDeleteConfirmation">
+                Delete
+            </button>
+
+            <ConfirmationDialog
+                Title="Delete Product"
+                Message="@($"Are you sure you want to delete '{Product.Name}'?")"
+                ConfirmButtonText="Delete"
+                Visible="@showDeleteDialog"
+                VisibleChanged="@DeleteDialogVisibilityChanged"
+                OnConfirmed="RaiseDeleteEvent" />
+        }
     </td>
 </tr>
 
@@ -60,20 +76,47 @@
     /// </summary>
     [Parameter]
     public EventCallback<List<int>> OnRemoveInstructions { get; set; }
+    
+    /// <summary>
+    /// Callback to notify the parent that this product should be deleted.
+    /// </summary>
+    [Parameter]
+    public EventCallback<Product> OnDeleteRequested { get; set; }
+
 
     /// <summary>
     /// An event callback triggered upon pushing the create/save button.
     /// </summary>
     [Parameter]
     public EventCallback<Product> OnSubmit { get; set; }
+    
+    private EventCallback<bool> DeleteDialogVisibilityChanged =>
+        EventCallback.Factory.Create<bool>(this, SetDeleteDialogVisibility);
 
     private bool IsNewProduct => Product.Id == 0;
     private bool isSaving = false;
+    
+    private bool showDeleteDialog;
 
     private async Task HandleSubmit()
     {
         isSaving = true;
         await OnSubmit.InvokeAsync(Product);
         isSaving = false;
+    }
+    
+    private void ShowDeleteConfirmation()
+    {
+        showDeleteDialog = true;
+    }
+
+    private async Task RaiseDeleteEvent()
+    {
+        await OnDeleteRequested.InvokeAsync(Product);
+    }
+    
+    private void SetDeleteDialogVisibility(bool visible)
+    {
+        showDeleteDialog = visible;
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor.css
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/ProductTableRow.razor.css
@@ -1,0 +1,17 @@
+.red-dot {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;    
+    height: 6px;
+    width: 6px;
+    background-color: red;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    z-index: 100;
+    pointer-events: none;
+}
+
+.save-button-container {
+    position: relative;
+    display: inline-block;
+}

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/AddWorkInstructionDialog.razor.css
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/AddWorkInstructionDialog.razor.css
@@ -1,0 +1,5 @@
+.scrollable-checkbox-container {
+    max-height: 300px;
+    overflow-y: auto;
+    padding-right: 5px;
+}

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/WorkInstructionSelector.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/WorkInstructionSelector.razor
@@ -1,45 +1,48 @@
 @using MESS.Data.Models
 
 <div class="mb-3">
-    <h5>Associated Work Instructions</h5>
+    <h5>Work Instructions</h5>
 
-    <div class="list-group scrollable-checkbox-container">
-        @if (Instructions == null)
-        {
-            <div class="list-group-item text-muted text-center">Loading work instructions...</div>
-        }
-        else if (!Instructions.Any())
-        {
-            <div class="list-group-item text-muted text-center">No associated work instructions.</div>
-        }
-        else
-        {
-            @foreach (var instruction in Instructions)
+    <div class="d-flex align-items-start">
+        <div class="list-group flex-grow-1 scrollable-checkbox-container me-2">
+            @if (Instructions == null)
             {
-                <label class="list-group-item">
-                    <input type="checkbox"
-                           class="form-check-input me-1"
-                           checked="@SelectedInstructionIds.Contains(instruction.Id)"
-                           @onchange="(e => ToggleSelection(instruction.Id, (bool)(e.Value ?? false)))" />
-                    @($"{instruction.Title} v{instruction.Version}")
-                </label>
+                <div class="list-group-item text-muted text-center">Loading work instructions...</div>
             }
-        }
-    </div>
+            else if (!Instructions.Any())
+            {
+                <div class="list-group-item text-muted text-center">No associated work instructions.</div>
+            }
+            else
+            {
+                @foreach (var instruction in Instructions)
+                {
+                    <label class="list-group-item">
+                        <input type="checkbox"
+                               class="form-check-input me-1"
+                               checked="@SelectedInstructionIds.Contains(instruction.Id)"
+                               @onchange="(e => ToggleSelection(instruction.Id, (bool)(e.Value ?? false)))" />
+                        @($"{instruction.Title} v{instruction.Version}")
+                    </label>
+                }
+            }
+        </div>
 
-    <div class="dropdown-container" style="position: relative; display: inline-block;">
-        <button class="btn btn-sm btn-light" @onclick="ToggleDropdown" aria-expanded="@IsDropdownOpen" aria-haspopup="true">
-            Actions
-        </button>
+        <div class="dropdown-container position-relative">
+            <button class="btn btn-sm btn-light bi bi-three-dots-vertical" @onclick="ToggleDropdown" 
+                    aria-expanded="@IsDropdownOpen" aria-haspopup="true"></button>
 
-        @if (IsDropdownOpen)
-        {
-            <div class="dropdown-menu-custom">
-                <button class="dropdown-item" @onclick="() => InvokeAction_Add()">Add Instructions</button>
-                <div class="dropdown-divider"></div>
-                <button class="dropdown-item text-danger" @onclick="() => InvokeAction_Remove()">Remove Selected</button>
-            </div>
-        }
+            @if (IsDropdownOpen)
+            {
+                <div class="dropdown-menu-custom">
+                    <button class="dropdown-item" @onclick="() => InvokeAction_Add()">Add Instructions</button>
+                    <div class="dropdown-divider"></div>
+                    <button class="dropdown-item text-danger" @onclick="() => InvokeAction_Remove()">
+                        Remove Selected
+                    </button>
+                </div>
+            }
+        </div>
     </div>
 </div>
 

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/WorkInstructionSelector.razor.css
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/ProductTableRow/WorkInstructionAssociation/WorkInstructionSelector.razor.css
@@ -2,6 +2,8 @@
     max-height: 300px;
     overflow-y: auto;
     border: 1px solid rgba(0,0,0,.125);
+    width: max-content; 
+    flex: 0 0 auto;
 }
 
 /* Adding hover effect */


### PR DESCRIPTION
This pull request brings some quality of life enhancements to the Phoebe Products page. 
* Products can now be deleted and a confirmation dialog is displayed before deletion.
* The save button is now displayed as a floppy disk (with an unsaved changes status light) and has been moved closer to the other elements in the row that are saved by clicking this button. 
* The checkboxes in the add products dialog for this page is now a scrollable region, making it easier to access the buttons at the bottom of the dialog when many work instructions are being listed.