### PR TITLE
Phoebe Bug Fixes and Work Instruction Editor Service Tests

### DIFF
--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/SortableList/SortableList.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/SortableList/SortableList.razor
@@ -1,4 +1,3 @@
-@using System.Collections.Generic
 @using System.Diagnostics.CodeAnalysis
 
 @inject IJSRuntime JS

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/SortableList/SortableList.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/SortableList/SortableList.razor
@@ -5,7 +5,7 @@
 
 @typeparam T
 
-<div id="@Id">
+<div id="@Id" @ref="containerRef">
     @foreach (var item in Items)
     {
         <div @key="item">
@@ -92,48 +92,63 @@
     public bool ForceFallback { get; set; } = true;
 
     private DotNetObjectReference<SortableList<T>>? selfReference;
+    private ElementReference containerRef;
+    private IJSObjectReference? moduleRef;
+    private bool initialized = false;
 
-    /// <summary>
-    /// Initializes the SortableJS integration after the component is rendered for the first time.
-    /// </summary>
-    /// <param name="firstRender">Indicates if this is the first render.</param>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (!initialized)
         {
-            selfReference = DotNetObjectReference.Create(this);
-            var module = await JS.InvokeAsync<IJSObjectReference>("import", "/SortableList.js");
-            await module.InvokeAsync<string>("init", Id, Group, Pull, Put, Sort, Handle, Filter, selfReference, ForceFallback);
+            try
+            {
+                selfReference = DotNetObjectReference.Create(this);
+                moduleRef = await JS.InvokeAsync<IJSObjectReference>("import", "/SortableList.js");
+
+                // Pass the ElementReference so JS receives the actual element (preferred).
+                await moduleRef.InvokeVoidAsync("init", containerRef, Group, Pull, Put, Sort, Handle, Filter, selfReference, ForceFallback);
+                initialized = true;
+            }
+            catch (JSException jsEx)
+            {
+                // defensive: log or handle and avoid crashing the circuit
+                Console.Error.WriteLine($"SortableList init failed: {jsEx.Message}");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"SortableList unexpected init error: {ex}");
+            }
         }
     }
 
-    /// <summary>
-    /// Called by JavaScript when an item is reordered within the list.
-    /// </summary>
-    /// <param name="oldIndex">The index the item was moved from.</param>
-    /// <param name="newIndex">The index the item was moved to.</param>
     [JSInvokable]
-    public void OnUpdateJS(int oldIndex, int newIndex)
-    {
-        // invoke the OnUpdate event passing in the oldIndex and the newIndex
-        OnUpdate.InvokeAsync((oldIndex, newIndex));
-    }
+    public Task OnUpdateJS(int oldIndex, int newIndex)
+        => OnUpdate.InvokeAsync((oldIndex, newIndex));
 
-    /// <summary>
-    /// Called by JavaScript when an item is removed from the list.
-    /// </summary>
-    /// <param name="oldIndex">The index the item was removed from.</param>
-    /// <param name="newIndex">The index it was moved to (typically -1).</param>
     [JSInvokable]
-    public void OnRemoveJS(int oldIndex, int newIndex)
-    {
-        // remove the item from the list
-        OnRemove.InvokeAsync((oldIndex, newIndex));
-    }
+    public Task OnRemoveJS(int oldIndex, int newIndex)
+        => OnRemove.InvokeAsync((oldIndex, newIndex));
 
-    /// <summary>
-    /// Disposes the DotNetObjectReference to avoid memory leaks.
-    /// </summary>
-    public void Dispose() => selfReference?.Dispose();
+    // Implement IAsyncDisposable to clean up the JS module and DotNetObjectReference.
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (moduleRef is not null)
+            {
+                // call destroy to remove Sortable instance on JS side
+                try { await moduleRef.InvokeVoidAsync("destroy", containerRef); } catch { /* ignore */ }
+                await moduleRef.DisposeAsync();
+            }
+        }
+        catch (Exception e)
+        {
+            Console.Error.WriteLine($"Error disposing SortableList module: {e}");
+        }
+        finally
+        {
+            selfReference?.Dispose();
+            selfReference = null;
+        }
+    }
 }
-

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/WorkInstructionNodeManagerList.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionNodes/WorkInstructionNodeManagerList.razor
@@ -49,36 +49,36 @@
     private Dictionary<int, string> ActiveFields { get; set; } = new();
 
     private RenderFragment<WorkInstructionNode> NodeTemplate => (node) =>
-    @<div id="node-@node.Position">
+        @<div id="node-@node.Position">
             <div class="d-flex mb-3 border rounded disable-highlight">
                 <div class="d-flex align-items-center drag-handle me-2">
-                    <i class="bi bi-grip-vertical h3" />
-                    <div class="vr me-2" />
+                    <i class="bi bi-grip-vertical h3"/>
+                    <div class="vr me-2"/>
                 </div>
                 <div class="flex-grow-1 my-1">
                     @switch (node)
                     {
-                    case PartNode partNode:
-                        <PartNodeView PartNode="partNode"
-                                      OnNodeAction="HandleNodeAction"
-                                      OnChanged="() => OnChanged.InvokeAsync(node)" />
-                        break;
+                        case PartNode partNode:
+                            <PartNodeView PartNode="partNode"
+                                          OnNodeAction="HandleNodeAction"
+                                          OnChanged="() => OnChanged.InvokeAsync(node)"/>
+                            break;
 
-                    case Step stepNode:
-                        <StepNodeView Step="stepNode"
-                                      EditorRefs="EditorRefs"
-                                      ActiveFields="ActiveFields"
-                                      OnAction="HandleNodeAction"
-                                      OnChanged="() => OnChanged.InvokeAsync(node)" />
-                        break;
+                        case Step stepNode:
+                            <StepNodeView Step="stepNode"
+                                          EditorRefs="EditorRefs"
+                                          ActiveFields="ActiveFields"
+                                          OnAction="HandleNodeAction"
+                                          OnChanged="() => OnChanged.InvokeAsync(node)"/>
+                            break;
 
-                    default:
-                        <div>Unknown node type: @node.NodeType</div>
-                        break;
+                        default:
+                            <div>Unknown node type: @node.NodeType</div>
+                            break;
                     }
-                </div>    
+                </div>
             </div>
-    </div>;
+        </div>;
 
     private async Task OnItemsChanged((int oldIndex, int newIndex) indices)
     {

--- a/MESS/MESS.Blazor/wwwroot/SortableList.js
+++ b/MESS/MESS.Blazor/wwwroot/SortableList.js
@@ -1,34 +1,92 @@
-export function init(id, group, pull, put, sort, handle, filter, component, forceFallback) {
-    var sortable = new Sortable(document.getElementById(id), {
-        animation: 200,
-        group: {
-            name: group,
-            pull: pull || true,
-            put: put
-        },
-        filter: filter || undefined,
-        sort: sort,
-        forceFallback: forceFallback,
-        handle: handle || undefined,
-        onUpdate: (event) => {
-            // Revert the DOM to match the .NET state
-            event.item.remove();
-            event.to.insertBefore(event.item, event.to.childNodes[event.oldIndex]);
+export function init(elOrRef, group, pull, put, sort, handle, filter, component, forceFallback) {
+    // Helper to get DOM element (either ElementReference marshalled by Blazor or an id string)
+    function getElement(candidate) {
+        if (!candidate) return null;
+        // If Blazor passed an ElementReference, it will be the actual element here
+        if (candidate instanceof HTMLElement) return candidate;
+        // otherwise if it's a string id
+        if (typeof candidate === 'string') return document.getElementById(candidate);
+        // could be a JS object wrapper from Blazor; try to read .then? but usually instance check is enough
+        return null;
+    }
 
-            // Notify .NET to update its model and re-render
-            component.invokeMethodAsync('OnUpdateJS', event.oldDraggableIndex, event.newDraggableIndex);
-        },
-        onRemove: (event) => {
-            if (event.pullMode === 'clone') {
-                // Remove the clone
-                event.clone.remove();
+    const MAX_TRIES = 10;
+    const TRY_DELAY_MS = 40;
+    let tries = 0;
+
+    function tryInit() {
+        const root = getElement(elOrRef);
+        if (!root) {
+            tries++;
+            if (tries <= MAX_TRIES) {
+                setTimeout(tryInit, TRY_DELAY_MS);
+                return;
+            } else {
+                console.warn('SortableList.init: element not found after retries', elOrRef);
+                return;
             }
-
-            event.item.remove();
-            event.from.insertBefore(event.item, event.from.childNodes[event.oldIndex]);
-
-            // Notify .NET to update its model and re-render
-            component.invokeMethodAsync('OnRemoveJS', event.oldDraggableIndex, event.newDraggableIndex);
         }
-    });
+
+        // avoid double-init on same element
+        if (root._sortable) {
+            // already initialized, nothing more to do
+            return;
+        }
+
+        const sortable = new Sortable(root, {
+            animation: 200,
+            group: {
+                name: group,
+                pull: pull || true,
+                put: put
+            },
+            filter: filter || undefined,
+            sort: sort,
+            forceFallback: forceFallback,
+            handle: handle || undefined,
+            onUpdate: (event) => {
+                // revert DOM to .NET state (existing behavior)
+                event.item.remove();
+                event.to.insertBefore(event.item, event.to.childNodes[event.oldIndex]);
+
+                // Notify .NET to update its model and re-render
+                component.invokeMethodAsync('OnUpdateJS', event.oldDraggableIndex, event.newDraggableIndex);
+            },
+            onRemove: (event) => {
+                if (event.pullMode === 'clone') {
+                    event.clone.remove();
+                }
+
+                event.item.remove();
+                event.from.insertBefore(event.item, event.from.childNodes[event.oldIndex]);
+
+                component.invokeMethodAsync('OnRemoveJS', event.oldDraggableIndex, event.newDraggableIndex);
+            }
+        });
+
+        // store a reference for cleanup
+        root._sortable = sortable;
+    }
+
+    tryInit();
+}
+
+// cleanup function to call from .NET
+export function destroy(elOrRef) {
+    function getElement(candidate) {
+        if (!candidate) return null;
+        if (candidate instanceof HTMLElement) return candidate;
+        if (typeof candidate === 'string') return document.getElementById(candidate);
+        return null;
+    }
+
+    const root = getElement(elOrRef);
+    if (root && root._sortable) {
+        try {
+            root._sortable.destroy();
+        } catch (e) {
+            console.warn('SortableList.destroy: error destroying sortable', e);
+        }
+        delete root._sortable;
+    }
 }

--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
@@ -1283,6 +1283,8 @@ public partial class WorkInstructionService : IWorkInstructionService
                 .ThenInclude(w => ((PartNode)w).Parts)
                 .FirstOrDefaultAsync(w => w.Id == id);
             
+            SortNodesByPosition(workInstruction);
+            
             return workInstruction;
         }
         catch (Exception e)
@@ -1290,6 +1292,19 @@ public partial class WorkInstructionService : IWorkInstructionService
             Log.Warning("Exception thrown when attempting to GetByIdAsync with ID: {id}, in WorkInstructionService. Exception: {Exception}", id, e.ToString());
             return null;
         }
+    }
+    
+    /// <summary>
+    /// Ensures that the WorkInstruction's Nodes are ordered by their Position property.
+    /// </summary>
+    private static void SortNodesByPosition(WorkInstruction? workInstruction)
+    {
+        if (workInstruction?.Nodes == null || workInstruction.Nodes.Count == 0)
+            return;
+
+        workInstruction.Nodes = workInstruction.Nodes
+            .OrderBy(n => n.Position)
+            .ToList();
     }
     
     /// <summary>

--- a/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
+++ b/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
@@ -2,7 +2,7 @@ using MESS.Services.CRUD.WorkInstructions;
 using Serilog;
 
 namespace MESS.Services.UI.WorkInstructionEditor;
-using MESS.Data.Models;
+using Data.Models;
 using System.Threading.Tasks;
 
 /// <inheritdoc />

--- a/MESS/MESS.Tests/Services/LineOperatorServiceTest.cs
+++ b/MESS/MESS.Tests/Services/LineOperatorServiceTest.cs
@@ -1,6 +1,0 @@
-namespace MESS.Tests;
-
-public class LineOperatorServiceTest
-{
-    
-}

--- a/MESS/MESS.Tests/Services/WorkInstructionEditorServiceTests.cs
+++ b/MESS/MESS.Tests/Services/WorkInstructionEditorServiceTests.cs
@@ -1,0 +1,159 @@
+using MESS.Data.Models;
+using MESS.Services.CRUD.WorkInstructions;
+using MESS.Services.UI.WorkInstructionEditor;
+using Moq;
+
+namespace MESS.Tests.Services;
+
+public class WorkInstructionEditorServiceTests
+{
+    private readonly Mock<IWorkInstructionService> _mockService;
+    private readonly WorkInstructionEditorService _sut;
+
+    public WorkInstructionEditorServiceTests()
+    {
+        _mockService = new Mock<IWorkInstructionService>();
+        _sut = new WorkInstructionEditorService(_mockService.Object);
+    }
+
+    [Fact]
+    public void StartNew_ShouldInitializeNewInstruction()
+    {
+        // Act
+        _sut.StartNew("Test WI");
+
+        // Assert
+        Assert.NotNull(_sut.Current);
+        Assert.Equal("Test WI", _sut.Current!.Title);
+        Assert.Equal("1.0", _sut.Current.Version);
+        Assert.Equal(EditorMode.CreateNew, _sut.Mode);
+        Assert.True(_sut.IsDirty);
+    }
+
+    [Fact]
+    public async Task StartNewFromCurrent_ShouldCloneFromCurrent()
+    {
+        // Arrange
+        _sut.StartNew("Base WI");
+        _sut.Current!.ShouldGenerateQrCode = true;
+        _sut.Current.Nodes.Add(new Step
+        {
+            Name = "Step 1",
+            Body = "Body 1"
+        });
+
+        _mockService.Setup(s => s.SaveImageFileAsync(It.IsAny<string>()))
+            .ReturnsAsync("cloned.png");
+
+        // Act
+        await _sut.StartNewFromCurrent("Cloned WI");
+
+        // Assert
+        Assert.NotNull(_sut.Current);
+        Assert.Equal("Cloned WI", _sut.Current!.Title);
+        Assert.Single(_sut.Current.Nodes);
+        Assert.Equal(EditorMode.CreateNew, _sut.Mode);
+    }
+
+    [Fact]
+    public async Task LoadForEditAsync_ShouldLoadExistingInstruction()
+    {
+        // Arrange
+        var wi = new WorkInstruction { Id = 42, Title = "Existing" };
+        _mockService.Setup(s => s.GetByIdAsync(42)).ReturnsAsync(wi);
+
+        // Act
+        await _sut.LoadForEditAsync(42);
+
+        // Assert
+        Assert.Equal(wi, _sut.Current);
+        Assert.Equal(EditorMode.EditExisting, _sut.Mode);
+        Assert.False(_sut.IsDirty);
+    }
+
+    [Fact]
+    public async Task LoadForEditAsync_NotFound_ShouldThrow()
+    {
+        _mockService.Setup(s => s.GetByIdAsync(99)).ReturnsAsync((WorkInstruction?)null);
+
+        await Assert.ThrowsAsync<Exception>(() => _sut.LoadForEditAsync(99));
+    }
+
+    [Fact]
+    public async Task SaveAsync_CreateNew_ShouldCallCreateAndMarkClean()
+    {
+        // Arrange
+        _sut.StartNew("New WI");
+        _mockService.Setup(s => s.Create(It.IsAny<WorkInstruction>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _sut.SaveAsync();
+
+        // Assert
+        Assert.True(result);
+        Assert.False(_sut.IsDirty);
+        Assert.Equal(EditorMode.EditExisting, _sut.Mode);
+        _mockService.Verify(s => s.Create(It.IsAny<WorkInstruction>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_EditExisting_ShouldCallUpdate()
+    {
+        // Arrange
+        var wi = new WorkInstruction { Id = 5, Title = "Existing" };
+        _mockService.Setup(s => s.GetByIdAsync(5)).ReturnsAsync(wi);
+        _mockService.Setup(s => s.UpdateWorkInstructionAsync(It.IsAny<WorkInstruction>()))
+            .ReturnsAsync(true);
+
+        // put service into EditExisting state properly
+        await _sut.LoadForEditAsync(5);
+
+        // Act
+        var result = await _sut.SaveAsync();
+
+        // Assert
+        Assert.True(result);
+        _mockService.Verify(s => s.UpdateWorkInstructionAsync(It.Is<WorkInstruction>(w => w.Id == 5)), Times.Once);
+    }
+
+    [Fact]
+    public void QueueNodeForDeletion_ShouldAddNode()
+    {
+        var node = new Step
+        {
+            Name = "Step A",
+            Body = "Body A"
+        };
+
+        _sut.QueueNodeForDeletion(node);
+
+        Assert.Contains(node, _sut.NodesQueuedForDeletion);
+    }
+
+    [Fact]
+    public void ToggleActive_ShouldFlipAndMarkDirty()
+    {
+        _sut.StartNew("WI");
+        var before = _sut.Current!.IsActive;
+
+        _sut.ToggleActive();
+
+        Assert.NotEqual(before, _sut.Current.IsActive);
+        Assert.True(_sut.IsDirty);
+    }
+
+    [Fact]
+    public void CurrentHasPartsOrSteps_ShouldReturnExpected()
+    {
+        _sut.StartNew("WI");
+        Assert.False(_sut.CurrentHasParts());
+        Assert.False(_sut.CurrentHasSteps());
+
+        _sut.Current!.Nodes.Add(new PartNode());
+        _sut.Current!.Nodes.Add(new Step { Name = "Some name", Body = "Some body" });
+
+        Assert.True(_sut.CurrentHasParts());
+        Assert.True(_sut.CurrentHasSteps());
+    }
+}


### PR DESCRIPTION
### New Features
* The `WorkInstructionEditorService` now features a set of unit tests.

### Bug Fixes
* Part Nodes now properly order themselves on initial load of a work instruction in Phoebe.
* The sortable list for work instruction nodes within Phoebe should not crash as often.

### Known Issues
* New work instruction nodes that have not yet been saved still have weird behavior (especially when it comes to keeping track of the show/hide details states.