### PR TITLE
New Parts Page for Managing Part Definitions

### DIFF
--- a/MESS/MESS.Blazor/Components/Navigator/NavigationMenu.razor
+++ b/MESS/MESS.Blazor/Components/Navigator/NavigationMenu.razor
@@ -45,6 +45,10 @@
                          href="/products" @onclick="OnToggleClicked">
                     Products
                 </NavLink>
+                <NavLink class="btn btn-sm btn-outline-secondary text-start"
+                         href="/parts" @onclick="OnToggleClicked">
+                    Parts
+                </NavLink>
             </AuthorizeView>
 
 

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
@@ -165,33 +165,50 @@ else
 
     private async Task HandleDeletePartDefinitionAsync(PartDefinition part)
     {
-        var result = await PartDefinitionService.DeleteAsync(part);
-
-        switch (result)
+        try
         {
-            case DeletePartDefinitionResult.Success:
-                ToastService.ShowSuccess($"Deleted part '{part.Name}'");
-                await LoadParts();
-                await _table.ReloadServerData();
-                break;
+            var response = await PartDefinitionService.DeleteAsync(part);
 
-            case DeletePartDefinitionResult.InUse:
-                ToastService.ShowWarning(
-                    $"Part '{part.Name}' cannot be deleted because it is still used by one or more part nodes."
-                );
-                break;
+            switch (response.Result)
+            {
+                case DeletePartDefinitionResult.Success:
+                    ToastService.ShowSuccess($"Deleted part '{part.Name}'.");
+                    await LoadParts();
+                    await _table.ReloadServerData();
+                    break;
 
-            case DeletePartDefinitionResult.NotFound:
-                ToastService.ShowWarning(
-                    $"Part '{part.Name}' no longer exists."
-                );
-                break;
+                case DeletePartDefinitionResult.InUse:
+                    // Build a readable message from usage info
+                    var usageList = string.Join(
+                        ", ",
+                        response.Usages
+                            .Select(u => $"{u.WorkInstructionTitle} (step {u.NodePosition + 1})"));
 
-            default:
-                ToastService.ShowError(
-                    $"An unexpected error occurred while deleting part '{part.Name}'."
-                );
-                break;
+                    ToastService.ShowWarning(
+                        $"Cannot delete part '{part.Name}' because it is used by: {usageList}");
+
+                    break;
+
+                case DeletePartDefinitionResult.NotFound:
+                    ToastService.ShowWarning(
+                        $"Part '{part.Name}' no longer exists.");
+
+                    await LoadParts();
+                    await _table.ReloadServerData();
+                    break;
+
+                case DeletePartDefinitionResult.Error:
+                default:
+                    ToastService.ShowError(
+                        $"An error occurred while deleting part '{part.Name}'.");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Defensive: this should be rare since DeleteAsync already handles errors
+            ToastService.ShowError(
+                $"Unexpected error deleting part '{part.Name}': {ex.Message}");
         }
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
@@ -1,0 +1,197 @@
+@page "/parts"
+@layout PhoebeLayout
+@attribute [Authorize(Roles = "Technician, Administrator")]
+@using MESS.Blazor.Components.Layout
+@using MESS.Data.Models
+@using MESS.Services.CRUD.PartDefinitions
+@using Microsoft.AspNetCore.Authorization
+@inject IPartDefinitionService PartDefinitionService
+@inject IToastService ToastService
+
+<PageTitle>Part Definitions</PageTitle>
+
+@if (PartDefinitions.Count == 0)
+{
+    <h3>Part Definitions</h3>
+    <p>No part definitions currently available.</p>
+}
+else
+{
+    <div class="d-flex justify-content-between my-2" style="flex-direction: row">
+        <h3>Part Definitions</h3>
+        <div class="flex-grow-1"/>
+        <input type="text" class="form-control w-auto" placeholder="Search..."
+               @bind="SearchString" @bind:event="oninput"  />
+    </div>
+
+    <MudTable @ref="_table"
+              T="PartDefinition"
+              ServerData="ServerReload"
+              Loading="_isLoading"
+              FixedHeader="true"
+              Class="border rounded-3 pt-1"
+              TableClass="table table-striped table-hover align-top"
+              CellClass="align-top">
+
+        <HeaderContent>
+            <MudTh><MudTableSortLabel SortLabel="name_field" SortBy="new Func<PartDefinition, object>(x => x.Name)"><strong>Name</strong></MudTableSortLabel></MudTh>
+            
+            <MudTh><MudTableSortLabel SortLabel="number_field" SortBy="new Func<PartDefinition, object>(x => x.Number ?? string.Empty)">
+                <strong>Number</strong>
+                </MudTableSortLabel></MudTh>
+            <MudTh><strong>Actions</strong></MudTh>
+        </HeaderContent>
+
+        <RowTemplate Context="part">
+            <PartDefinitionTableRow 
+                PartDefinition="part"
+                OnSubmit="@SubmitPartDefinitionCallback"
+                OnDeleteRequested="@HandleDeletePartDefinitionAsync" />
+        </RowTemplate>
+
+        <FooterContent>
+            <PartDefinitionTableRow
+                PartDefinition="_newPart"
+                OnSubmit="@SubmitPartDefinitionCallback" />
+        </FooterContent>
+
+        <PagerContent>
+            <MudTablePager InfoFormat="@InfoFormat()" HorizontalAlignment="MudBlazor.HorizontalAlignment.Center" RowsPerPageString="Rows per Page" />
+        </PagerContent>
+    </MudTable>
+}
+
+@code {
+    private List<PartDefinition> PartDefinitions { get; set; } = new();
+    private PartDefinition _newPart = new() { Name = "", Number = "" };
+    private MudTable<PartDefinition> _table = new();
+    private bool _isLoading;
+    private int _totalItems;
+    private string _searchString = "";
+    private string SearchString
+    {
+        get => _searchString;
+        set
+        {
+            _searchString = value;
+            _table.ReloadServerData();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadParts();
+    }
+
+    private async Task LoadParts()
+    {
+        _isLoading = true;
+
+        try
+        {
+            // Use the new GetAllAsync to retrieve all parts
+            PartDefinitions = (await PartDefinitionService.GetAllAsync()).ToList();
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to load parts: {ex.Message}");
+            PartDefinitions = new();
+        }
+
+        // Reset the new part row
+        _newPart = new PartDefinition { Name = "", Number = "" };
+
+        _isLoading = false;
+    }
+    
+    private Task<TableData<PartDefinition>> ServerReload(TableState state, CancellationToken token)
+    {
+        var data = PartDefinitions.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(SearchString))
+        {
+            data = data.Where(p => (p.Name.Contains(SearchString, StringComparison.OrdinalIgnoreCase)) ||
+                                   (p.Number?.Contains(SearchString, StringComparison.OrdinalIgnoreCase) ?? false));
+        }
+
+        _totalItems = data.Count();
+
+        data = state.SortLabel switch
+        {
+            "name_field" => state.SortDirection == MudBlazor.SortDirection.Ascending
+                ? data.OrderBy(p => p.Name)
+                : data.OrderByDescending(p => p.Name),
+            "number_field" => state.SortDirection == MudBlazor.SortDirection.Ascending
+                ? data.OrderBy(p => p.Number ?? string.Empty)
+                : data.OrderByDescending(p => p.Number ?? string.Empty),
+            _ => data
+        };
+
+        var paged = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToArray();
+
+        // Return a completed task instead of using async/await
+        return Task.FromResult(new TableData<PartDefinition> { TotalItems = _totalItems, Items = paged });
+    }
+    
+    private string InfoFormat() => $"Page {_table.CurrentPage + 1} of {(_totalItems / _table.RowsPerPage) + 1}";
+
+    private EventCallback<PartDefinition> SubmitPartDefinitionCallback =>
+        EventCallback.Factory.Create<PartDefinition>(this, HandleSubmitPartAsync);
+
+    private async Task HandleSubmitPartAsync(PartDefinition part)
+    {
+        try
+        {
+            if (part.Id == 0)
+            {
+                var created = await PartDefinitionService.GetOrAddPartAsync(part);
+                if (created != null) ToastService.ShowSuccess($"Created part '{created.Name}'");
+            }
+            else
+            {
+                // For now, use GetOrAddPartAsync to update
+                var updated = await PartDefinitionService.GetOrAddPartAsync(part);
+                if (updated != null) ToastService.ShowSuccess($"Updated part '{updated.Name}'");
+            }
+
+            await LoadParts();
+            await _table.ReloadServerData();
+        }
+        catch (Exception ex)
+        {
+            ToastService.ShowError($"Failed to submit part '{part.Name}': {ex.Message}");
+        }
+    }
+
+    private async Task HandleDeletePartDefinitionAsync(PartDefinition part)
+    {
+        var result = await PartDefinitionService.DeleteAsync(part);
+
+        switch (result)
+        {
+            case DeletePartDefinitionResult.Success:
+                ToastService.ShowSuccess($"Deleted part '{part.Name}'");
+                await LoadParts();
+                await _table.ReloadServerData();
+                break;
+
+            case DeletePartDefinitionResult.InUse:
+                ToastService.ShowWarning(
+                    $"Part '{part.Name}' cannot be deleted because it is still used by one or more part nodes."
+                );
+                break;
+
+            case DeletePartDefinitionResult.NotFound:
+                ToastService.ShowWarning(
+                    $"Part '{part.Name}' no longer exists."
+                );
+                break;
+
+            default:
+                ToastService.ShowError(
+                    $"An unexpected error occurred while deleting part '{part.Name}'."
+                );
+                break;
+        }
+    }
+}

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionManager.razor
@@ -142,18 +142,34 @@ else
     {
         try
         {
+            PartDefinition? result;
+
             if (part.Id == 0)
             {
-                var created = await PartDefinitionService.GetOrAddPartAsync(part);
-                if (created != null) ToastService.ShowSuccess($"Created part '{created.Name}'");
+                result = await PartDefinitionService.CreateAsync(part);
+
+                if (result is null)
+                {
+                    ToastService.ShowError($"Failed to create part '{part.Name}'.");
+                    return;
+                }
+
+                ToastService.ShowSuccess($"Created part '{result.Name}'.");
             }
             else
             {
-                // For now, use GetOrAddPartAsync to update
-                var updated = await PartDefinitionService.GetOrAddPartAsync(part);
-                if (updated != null) ToastService.ShowSuccess($"Updated part '{updated.Name}'");
+                result = await PartDefinitionService.UpdateAsync(part);
+
+                if (result is null)
+                {
+                    ToastService.ShowError($"Failed to update part '{part.Name}'.");
+                    return;
+                }
+
+                ToastService.ShowSuccess($"Updated part '{result.Name}'.");
             }
 
+            // Refresh data after a successful write
             await LoadParts();
             await _table.ReloadServerData();
         }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionTableRow.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionTableRow.razor
@@ -1,0 +1,95 @@
+@using MESS.Data.Models
+@using MESS.Blazor.Components.Dialogs
+@inject Microsoft.FluentUI.AspNetCore.Components.IDialogService DialogService
+
+<MudTd DataLabel="Name">
+    <InputText id="name" @bind-Value="PartDefinition.Name" class="form-control" placeholder="Enter part name" @oninput="OnInputChanged"/>
+</MudTd>
+<MudTd DataLabel="Number">
+    <InputText id="number" @bind-Value="PartDefinition.Number" class="form-control" placeholder="Enter part number (optional)" @oninput="OnInputChanged"/>
+</MudTd>
+<MudTd DataLabel="Actions">
+    @if (!IsNewPart)
+    {
+        <div class="save-button-container">
+            <button class="btn btn-sm btn-success" @onclick="HandleSubmit" disabled="@isSaving" title="Save">
+                <i class="bi bi-floppy"></i>
+                @if (IsDirty)
+                {
+                    <span class="red-dot"></span>
+                }
+            </button>
+        </div>
+        <button class="btn btn-sm btn-danger ms-2" @onclick="ShowDeleteConfirmation">
+            <i class="bi bi-trash" />
+        </button>
+    }
+    else
+    {
+        <button class="btn btn-sm btn-primary" @onclick="HandleSubmit" disabled="@isSaving">
+            <i class="bi bi-plus-lg"></i>
+        </button>
+    }
+</MudTd>
+
+@code {
+    /// <summary>
+    /// The part definition associated with this row.
+    /// </summary>
+    [Parameter]
+    public required PartDefinition PartDefinition { get; set; }
+
+    /// <summary>
+    /// Callback to notify the parent that this part should be deleted.
+    /// </summary>
+    [Parameter]
+    public EventCallback<PartDefinition> OnDeleteRequested { get; set; }
+
+    /// <summary>
+    /// Event callback triggered when saving/creating the part.
+    /// </summary>
+    [Parameter]
+    public EventCallback<PartDefinition> OnSubmit { get; set; }
+
+    private bool IsNewPart => PartDefinition.Id == 0;
+    private bool isSaving = false;
+    private bool IsDirty { get; set; } = false;
+
+    private void OnInputChanged(ChangeEventArgs e)
+    {
+        IsDirty = true;
+    }
+
+    private async Task HandleSubmit()
+    {
+        if (!IsDirty)
+            return;
+
+        isSaving = true;
+        await OnSubmit.InvokeAsync(PartDefinition);
+        isSaving = false;
+        IsDirty = false;
+    }
+
+    private async Task ShowDeleteConfirmation()
+    {
+        var data = (
+            bodyMessage: $"Are you sure you want to delete '{PartDefinition.Name}'?", 
+            callback: EventCallback.Factory.Create(this, RaiseDeleteEvent)
+        );
+        
+        var dialog =  await DialogService.ShowDialogAsync<ConfirmationDialog>(data, new Microsoft.FluentUI.AspNetCore.Components.DialogParameters()
+        {
+            Title = $"Delete Part",
+            PreventScroll = true,
+            PreventDismissOnOverlayClick = true,
+        });
+
+        await dialog.Result;
+    }
+
+    private async Task RaiseDeleteEvent()
+    {
+        await OnDeleteRequested.InvokeAsync(PartDefinition);
+    }
+}

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionTableRow.razor.css
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/PartManagement/PartDefinitionTableRow.razor.css
@@ -1,0 +1,17 @@
+.red-dot {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    height: 6px;
+    width: 6px;
+    background-color: red;
+    border-radius: 50%;
+    border: 1px solid transparent;
+    z-index: 100;
+    pointer-events: none;
+}
+
+.save-button-container {
+    position: relative;
+    display: inline-block;
+}

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/WorkInstructionNodes/StepNodeListItem.razor
@@ -386,61 +386,67 @@
         _currentAttemptNotes = attempt.FailureNote ?? "";
         ShowOptionalNotesField = true;
     }
-
+    
     private async Task HandleButtonPressAll(bool? result)
     {
-        if (!result.HasValue)
+        if (result is null)
             return;
+
+        var isSuccess = result.Value;
+        var now = DateTimeOffset.UtcNow;
 
         _pendingFailureAttempt = null;
 
-        if (!result.Value) // failure
+        if (!isSuccess)
         {
-            // Clear failure note before creating new attempts
             _currentAttemptNotes = "";
 
-            var newFailureAttempt = new StepAttemptFormDTO
+            var failureAttempt = new StepAttemptFormDTO
             {
                 IsSuccess = false,
-                SubmitTime = DateTimeOffset.UtcNow,
+                SubmitTime = now,
                 FailureNote = ""
             };
 
-            foreach (var step in LogSteps)
-            {
-                step.Attempts.Add(newFailureAttempt);
-            }
+            AddAttemptToAllSteps(failureAttempt);
 
-            _pendingFailureAttempt = newFailureAttempt; // Track the failure attempt for note editing
+            _pendingFailureAttempt = failureAttempt;
             ShowOptionalNotesField = true;
 
-            if (_failureNoteTextArea?.Element != null)
-            {
-                await JsRuntime.InvokeVoidAsync("AutoFocus.setFocus", _failureNoteTextArea.Id);
-            }
+            await FocusFailureNotesAsync();
         }
-        else // success
+        else
         {
-            foreach (var step in LogSteps)
+            AddAttemptToAllSteps(new StepAttemptFormDTO
             {
-                step.Attempts.Add(new StepAttemptFormDTO
-                {
-                    IsSuccess = true,
-                    SubmitTime = DateTimeOffset.UtcNow,
-                    FailureNote = ""
-                });
-            }
+                IsSuccess = true,
+                SubmitTime = now,
+                FailureNote = ""
+            });
 
             ShowOptionalNotesField = false;
             _currentAttemptNotes = "";
         }
 
-        SetSelectedButton(result.Value ? "Success" : "Failure");
+        SetSelectedButton(isSuccess ? "Success" : "Failure");
 
-        await OnStepCompleted.InvokeAsync((LogSteps, result.Value));
-        await ShowFloatMessage(result.Value ? "all-success" : "all-failure");
+        await OnStepCompleted.InvokeAsync((LogSteps, isSuccess));
+        await ShowFloatMessage(isSuccess ? "all-success" : "all-failure");
     }
 
+    private void AddAttemptToAllSteps(StepAttemptFormDTO attempt)
+    {
+        foreach (var step in LogSteps)
+        step.Attempts.Add(attempt);
+    }
+
+    private async Task FocusFailureNotesAsync()
+    {
+        if (_failureNoteTextArea?.Element is null)
+        return;
+
+        await JsRuntime.InvokeVoidAsync("AutoFocus.setFocus", _failureNoteTextArea.Id);
+    }
     
     private async Task HandleButtonPressIndexed(bool isSuccess)
     {

--- a/MESS/MESS.Services/CRUD/PartDefinitions/DeletePartDefinitionResult.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/DeletePartDefinitionResult.cs
@@ -1,0 +1,30 @@
+using MESS.Data.Models;
+
+namespace MESS.Services.CRUD.PartDefinitions;
+
+/// <summary>
+/// Represents the result of attempting to delete a <see cref="PartDefinition"/>.
+/// </summary>
+public enum DeletePartDefinitionResult
+{
+    /// <summary>
+    /// The part definition was successfully deleted.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The part definition could not be deleted because it is referenced
+    /// by one or more dependent entities.
+    /// </summary>
+    InUse,
+
+    /// <summary>
+    /// The part definition could not be found.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// An unexpected error occurred while attempting to delete the part definition.
+    /// </summary>
+    Error
+}

--- a/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
@@ -1,5 +1,5 @@
 using MESS.Data.Models;
-using Microsoft.EntityFrameworkCore;
+using MESS.Services.DTOs.PartDefinitions;
 
 namespace MESS.Services.CRUD.PartDefinitions;
 
@@ -168,18 +168,41 @@ public interface IPartDefinitionService
     Task<bool> ExistsAsync(string name, string? number = null);
     
     /// <summary>
-    /// Attempts to delete the specified <see cref="PartDefinition"/>.
+    /// Deletes the specified <see cref="PartDefinition"/> if it is not referenced by any work instruction nodes.
     /// </summary>
     /// <param name="partDefinition">
-    /// The part definition to delete.
+    /// The part definition to delete. The <see cref="PartDefinition.Id"/> must be a valid, persisted identifier.
     /// </param>
     /// <returns>
-    /// A <see cref="DeletePartDefinitionResult"/> indicating the outcome of the delete operation.
+    /// A <see cref="DeletePartDefinitionResponse"/> indicating the outcome of the operation:
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <see cref="DeletePartDefinitionResult.Success"/> if the part definition was deleted.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="DeletePartDefinitionResult.InUse"/> if the part definition is referenced by one or more
+    /// <see cref="PartNode"/> instances, along with details describing where it is used.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="DeletePartDefinitionResult.NotFound"/> if the part definition does not exist.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <see cref="DeletePartDefinitionResult.Error"/> if an unexpected error occurs during deletion.
+    /// </description>
+    /// </item>
+    /// </list>
     /// </returns>
     /// <remarks>
-    /// This method performs validation to ensure the part definition can be safely deleted.
-    /// If the part definition is referenced by other entities (for example, part nodes),
-    /// the delete operation will fail and return <see cref="DeletePartDefinitionResult.InUse"/>.
+    /// This operation performs a usage check against existing work instructions before deletion.
+    /// No deletion is performed if the part definition is currently in use.
     /// </remarks>
-    Task<DeletePartDefinitionResult> DeleteAsync(PartDefinition partDefinition);
+    Task<DeletePartDefinitionResponse> DeleteAsync(PartDefinition partDefinition);
+
 }

--- a/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
@@ -1,4 +1,5 @@
 using MESS.Data.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace MESS.Services.CRUD.PartDefinitions;
 
@@ -165,4 +166,20 @@ public interface IPartDefinitionService
     /// part exists; otherwise, <c>false</c>.
     /// </returns>
     Task<bool> ExistsAsync(string name, string? number = null);
+    
+    /// <summary>
+    /// Attempts to delete the specified <see cref="PartDefinition"/>.
+    /// </summary>
+    /// <param name="partDefinition">
+    /// The part definition to delete.
+    /// </param>
+    /// <returns>
+    /// A <see cref="DeletePartDefinitionResult"/> indicating the outcome of the delete operation.
+    /// </returns>
+    /// <remarks>
+    /// This method performs validation to ensure the part definition can be safely deleted.
+    /// If the part definition is referenced by other entities (for example, part nodes),
+    /// the delete operation will fail and return <see cref="DeletePartDefinitionResult.InUse"/>.
+    /// </remarks>
+    Task<DeletePartDefinitionResult> DeleteAsync(PartDefinition partDefinition);
 }

--- a/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
@@ -73,6 +73,20 @@ public interface IPartDefinitionService
     /// It does <b>not</b> include the part defined in <see cref="WorkInstruction.PartProduced"/>.
     /// </remarks>
     Task<List<PartDefinition>> GetByWorkInstructionIdAsync(int workInstructionId);
+    
+    /// <summary>
+    /// Retrieves all <see cref="PartDefinition"/> entities from the database.
+    /// </summary>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains
+    /// a list of all <see cref="PartDefinition"/> objects currently stored in the database.
+    /// </returns>
+    /// <remarks>
+    /// This method returns all parts in a detached state (using <c>AsNoTracking</c>),
+    /// which means the returned entities are not tracked by the EF Core change tracker.
+    /// This is suitable for read-only operations, such as displaying in tables or dropdowns.
+    /// </remarks>
+    Task<List<PartDefinition>> GetAllAsync();
 
     /// <summary>
     /// Retrieves a list of <see cref="PartDefinition"/> entities that are

--- a/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/IPartDefinitionService.cs
@@ -55,6 +55,51 @@ public interface IPartDefinitionService
     /// If a new entity is created, its <see cref="PartDefinition.Number"/> property will be set to <c>null</c>.
     /// </remarks>
     Task<PartDefinition?> GetOrCreateByNameAsync(string name);
+    
+    /// <summary>
+    /// Creates a new <see cref="PartDefinition"/> record in the database.
+    /// </summary>
+    /// <param name="part">
+    /// The <see cref="PartDefinition"/> to create. The <see cref="PartDefinition.Id"/>
+    /// property must be zero; the database will generate the identity value.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous operation. The task result contains
+    /// the newly created <see cref="PartDefinition"/> with its database-generated
+    /// identifier populated, or <c>null</c> if creation failed.
+    /// </returns>
+    /// <remarks>
+    /// This method is intended exclusively for creating new part definitions.
+    /// It must not be used to update existing records.
+    /// <para/>
+    /// Callers should ensure that the provided <paramref name="part"/> does not
+    /// conflict with existing part definitions (for example, duplicate name/number
+    /// combinations) before invoking this method.
+    /// </remarks>
+    Task<PartDefinition?> CreateAsync(PartDefinition part);
+    
+    /// <summary>
+    /// Updates an existing <see cref="PartDefinition"/> record in the database.
+    /// </summary>
+    /// <param name="part">
+    /// A <see cref="PartDefinition"/> containing the updated values. The
+    /// <see cref="PartDefinition.Id"/> must correspond to an existing database record.
+    /// </param>
+    /// <returns>
+    /// A task representing the asynchronous operation. The task result contains
+    /// the updated <see cref="PartDefinition"/> if the update succeeds, or
+    /// <c>null</c> if the target record does not exist or the operation fails.
+    /// </returns>
+    /// <remarks>
+    /// This method performs a controlled update of an existing part definition.
+    /// The target entity is loaded from the database and updated field-by-field
+    /// to avoid identity insert errors and unintended data overwrites.
+    /// <para/>
+    /// This method must not be used to create new part definitions. To create a new
+    /// record, use <see cref="CreateAsync(PartDefinition)"/> instead.
+    /// </remarks>
+    Task<PartDefinition?> UpdateAsync(PartDefinition part);
+
 
 
     /// <summary>

--- a/MESS/MESS.Services/CRUD/PartDefinitions/PartDefinitionService.cs
+++ b/MESS/MESS.Services/CRUD/PartDefinitions/PartDefinitionService.cs
@@ -169,6 +169,33 @@ public class PartDefinitionService : IPartDefinitionService
     }
     
     /// <summary>
+    /// Retrieves all <see cref="PartDefinition"/> entities in the database.
+    /// </summary>
+    /// <returns>A task that returns a list of all <see cref="PartDefinition"/> objects.</returns>
+    public async Task<List<PartDefinition>> GetAllAsync()
+    {
+        try
+        {
+            await using var context = await _contextFactory.CreateDbContextAsync();
+
+            // Use AsNoTracking for performance since we don't intend to update these
+            var parts = await context.PartDefinitions
+                .AsNoTracking()
+                .OrderBy(p => p.Name) // optional: sort by Name by default
+                .ToListAsync();
+
+            Log.Information("Retrieved {Count} PartDefinitions from the database.", parts.Count);
+
+            return parts;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error retrieving all PartDefinitions.");
+            return [];
+        }
+    }
+    
+    /// <summary>
     /// Retrieves all <see cref="PartDefinition"/> entities that are referenced
     /// by <see cref="PartNode"/> elements within a specified <see cref="WorkInstruction"/>.
     /// </summary>

--- a/MESS/MESS.Services/DTOs/PartDefinitions/DeletePartDefinitionResponse.cs
+++ b/MESS/MESS.Services/DTOs/PartDefinitions/DeletePartDefinitionResponse.cs
@@ -1,0 +1,29 @@
+using MESS.Services.CRUD.PartDefinitions;
+
+namespace MESS.Services.DTOs.PartDefinitions;
+
+/// <summary>
+/// Represents the result of an attempt to delete a <see cref="Data.Models.PartDefinition"/>.
+/// </summary>
+/// <remarks>
+/// This response provides both the high-level outcome of the delete operation and,
+/// when applicable, detailed information about why the deletion could not be completed.
+/// </remarks>
+public sealed class DeletePartDefinitionResponse
+{
+    /// <summary>
+    /// Gets the outcome of the delete operation.
+    /// </summary>
+    public DeletePartDefinitionResult Result { get; init; }
+
+    /// <summary>
+    /// Gets a collection describing where the part definition is currently used.
+    /// </summary>
+    /// <remarks>
+    /// This property is populated only when <see cref="Result"/> is
+    /// <see cref="DeletePartDefinitionResult.InUse"/>. Each entry identifies a work instruction
+    /// and specific part node position that references the part definition.
+    /// </remarks>
+    public IReadOnlyList<PartDefinitionUsage> Usages { get; init; }
+        = Array.Empty<PartDefinitionUsage>();
+}

--- a/MESS/MESS.Services/DTOs/PartDefinitions/PartDefinitionUsage.cs
+++ b/MESS/MESS.Services/DTOs/PartDefinitions/PartDefinitionUsage.cs
@@ -1,0 +1,36 @@
+namespace MESS.Services.DTOs.PartDefinitions;
+
+/// <summary>
+/// Represents a single usage of a <see cref="Data.Models.PartDefinition"/> within a work instruction.
+/// </summary>
+/// <remarks>
+/// This DTO is used when an operation (such as deletion) needs to report where a part definition
+/// is currently referenced, including the specific work instruction and node position in which
+/// it appears.
+/// </remarks>
+public sealed class PartDefinitionUsage
+{
+    /// <summary>
+    /// Gets the identifier of the work instruction that references the part definition.
+    /// </summary>
+    public int WorkInstructionId { get; init; }
+
+    /// <summary>
+    /// Gets the display title of the work instruction that references the part definition.
+    /// </summary>
+    public string WorkInstructionTitle { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Gets the identifier of the part node that references the part definition.
+    /// </summary>
+    public int PartNodeId { get; init; }
+
+    /// <summary>
+    /// Gets the positional index of the part node within the work instruction.
+    /// </summary>
+    /// <remarks>
+    /// This value represents the order or sequence of the node as defined by the work instruction,
+    /// and can be used to locate the reference within the instruction's structure.
+    /// </remarks>
+    public int NodePosition { get; init; }
+}


### PR DESCRIPTION
### New Feature
This pull request includes a new Phoebe administration page for creating, updating, and deleting part definitions. 

NOTE: Deleting part definitions will require that they are not part of any work instruction. This means that most (if not all) part definitions in use will not be possible to delete.

### Internal Blazor Component Changes
Behind the scenes, logic and code clarity for step node buttons have also been improved.