### PR TITLE
Part Traceability Improvements and Part Information Fix for Operators

### DIFF
--- a/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
+++ b/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
@@ -25,12 +25,12 @@
             <p class="me-1">
                 Product:<br/>
                 Instruction:<br/>
-                @* Product SN:<br/> *@
+                Part Produced:<br/>
             </p>
             <p class="ms-1">
                 @shownLog.ProductName<br/>
                 @shownLog.WorkInstructionName<br/>
-                @* The Part Produced from the Log? *@ 
+                @shownLog.ProducedPartName<br/>
             </p>
         </div>
 
@@ -53,10 +53,12 @@
             <p class="me-1">
                 Created On:<br/>
                 Last Modified On:<br/>
+                Produced Part SN:<br/>
             </p>
             <p class="ms-1">
                 @shownLog?.CreatedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
                 @shownLog?.LastModifiedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
+                @shownLog?.ProducedPartSerialNumber<br/>
             </p>
         </div>
         </div>

--- a/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
+++ b/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
@@ -63,10 +63,10 @@
                     </p>
                 </div>
 
-                <button @onclick="ToggleParts"
+                @*<button @onclick="ToggleParts"
                         class="btn btn-sm btn-outline-secondary ms-auto align-self-center">
                     @(showParts ? "View Steps" : "View Installed Parts")
-                </button>
+                </button>*@
             </div>
         </div>
 

--- a/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
+++ b/MESS/MESS.Blazor/Components/Dialogs/LogOptionsDialog.razor
@@ -1,4 +1,5 @@
-﻿@using MESS.Services.CRUD.ProductionLogs
+﻿@using MESS.Data.Models
+@using MESS.Services.CRUD.ProductionLogs
 @using MESS.Services.DTOs.ProductionLogs.Detail
 @using MESS.Services.DTOs.ProductionLogs.LogSteps.Attempts.Detail
 @using Microsoft.AspNetCore.Components.Authorization
@@ -21,100 +22,152 @@
     @if (shownLog is not null)
     {
         <div class="d-flex mx-1" style="flex-direction: row">
-        <div class="d-flex me-5" style="flex-direction: row">
-            <p class="me-1">
-                Product:<br/>
-                Instruction:<br/>
-                Part Produced:<br/>
-            </p>
-            <p class="ms-1">
-                @shownLog.ProductName<br/>
-                @shownLog.WorkInstructionName<br/>
-                @shownLog.ProducedPartName<br/>
-            </p>
-        </div>
-
-        @if (ShowPersonalInfo)
-        {
-            <div class="d-flex mx-5" style="flex-direction: row">
+            <div class="d-flex me-5 w-25" style="flex-direction: row">
                 <p class="me-1">
-                    Created By:<br/>
-                    Last Modified By:<br/>
+                    Product:<br/>
+                    Instruction:<br/>
+                    Part Produced:<br/>
+                    Produced Part SN:<br/>
                 </p>
                 <p class="ms-1">
-                    @shownLog?.CreatedBy<br/>
-                    @shownLog?.LastModifiedBy<br/>
+                    @shownLog.ProductName<br/>
+                    @shownLog.WorkInstructionName<br/>
+                    @shownLog.ProducedPartName<br/>
+                    @shownLog?.ProducedPartSerialNumber<br/>
                 </p>
             </div>
-        }
 
+            @if (ShowPersonalInfo)
+            {
+                <div class="d-flex mx-5" style="flex-direction: row">
+                    <p class="me-1">
+                        Created By:<br/>
+                        Last Modified By:<br/>
+                    </p>
+                    <p class="ms-1">
+                        @shownLog?.CreatedBy<br/>
+                        @shownLog?.LastModifiedBy<br/>
+                    </p>
+                </div>
+            }
+        
+            <div class="d-flex mx-5 w-100 align-items-start">
+                <div class="d-flex">
+                    <p class="me-1">
+                        Created On:<br/>
+                        Last Modified On:<br/>
+                    </p>
+                    <p class="ms-1">
+                        @shownLog?.CreatedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
+                        @shownLog?.LastModifiedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
+                    </p>
+                </div>
 
-        <div class="d-flex mx-5" style="flex-direction: row">
-            <p class="me-1">
-                Created On:<br/>
-                Last Modified On:<br/>
-                Produced Part SN:<br/>
-            </p>
-            <p class="ms-1">
-                @shownLog?.CreatedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
-                @shownLog?.LastModifiedOn.LocalDateTime.ToString("yyyy-MM-dd HH:mm")<br/>
-                @shownLog?.ProducedPartSerialNumber<br/>
-            </p>
+                <button @onclick="ToggleParts"
+                        class="btn btn-sm btn-outline-secondary ms-auto align-self-center">
+                    @(showParts ? "View Steps" : "View Installed Parts")
+                </button>
+            </div>
         </div>
-        </div>
 
-        <MudTable @ref="table"
+        @switch (showParts)
+        {
+            case false:
+                <MudTable @ref="stepTable"
                   ServerData="ServerReload"
                   Height="250px"
                   Loading="@IsLoading"
                   Class="border rounded-3 pt-1"
                   TableClass="fixed-header-cell table table-striped">
-            <ColGroup>
-                <col style="width: 45%"/>
-                <col/>
-                <col/>
-                <col style="width: 20%"/>
-                <col/>
-            </ColGroup>
-            <HeaderContent>
-                <MudTh>Step Name</MudTh>
-                <MudTh>Submit Time</MudTh>
-                <MudTh>Status</MudTh>
-                <MudTh>Failure Notes</MudTh>
-                <MudTh>Delete</MudTh>
-            </HeaderContent>
-            <RowTemplate>
-                <MudTd DataLabel="Step Name">@context.StepName</MudTd>
-                <MudTd DataLabel="Submit Time">@context.SubmitTime.LocalDateTime.ToString("yyyy-MM-dd HH:mm")</MudTd>
-                <MudTd DataLabel="Status">
-                    <button class="btn btn-sm @(context.IsSuccess ? "btn-success confirmed" : "btn-outline-success pending")"
-                            @onclick="() => UpdateStatus(context, true)">
-                        Success
-                    </button>
-                    <button class="btn btn-sm @(!context.IsSuccess ? "btn-danger failed" : "btn-outline-danger")"
-                            @onclick="() => UpdateStatus(context, false)">
-                        Failure
-                    </button>
-                </MudTd>
-                <MudTd DataLabel="Failure Notes">
-                    @if (!context.IsSuccess) @* Show textarea only if not success *@
-                    {
-                        <textarea class="form-control form-control-sm"
-                              rows="1"
-                              @bind="context.FailureNote"
-                              placeholder="Optional failure note" />
-                    }
-                </MudTd>
-                <MudTd DataLabel="Delete">
-                    <button class="btn btn-sm btn-danger" @onclick="@(() => HandleAttemptDeleted(context))">
-                        Delete
-                    </button>
-                </MudTd>
-            </RowTemplate>
-            <PagerContent>
-                <MudTablePager/>
-            </PagerContent>
-        </MudTable>
+                    <ColGroup>
+                        <col style="width: 45%"/>
+                        <col/>
+                        <col/>
+                        <col style="width: 20%"/>
+                        <col/>
+                    </ColGroup>
+                    <HeaderContent>
+                        <MudTh>Step Name</MudTh>
+                        <MudTh>Submit Time</MudTh>
+                        <MudTh>Status</MudTh>
+                        <MudTh>Failure Notes</MudTh>
+                        <MudTh>Delete</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Step Name">@context.StepName</MudTd>
+                        <MudTd DataLabel="Submit Time">@context.SubmitTime.LocalDateTime.ToString("yyyy-MM-dd HH:mm")</MudTd>
+                        <MudTd DataLabel="Status">
+                            <button class="btn btn-sm @(context.IsSuccess ? "btn-success confirmed" : "btn-outline-success pending")"
+                                    @onclick="() => UpdateStatus(context, true)">
+                                Success
+                            </button>
+                            <button class="btn btn-sm @(!context.IsSuccess ? "btn-danger failed" : "btn-outline-danger")"
+                                    @onclick="() => UpdateStatus(context, false)">
+                                Failure
+                            </button>
+                        </MudTd>
+                        <MudTd DataLabel="Failure Notes">
+                            @if (!context.IsSuccess) @* Show textarea only if not success *@
+                            {
+                                <textarea class="form-control form-control-sm"
+                                      rows="1"
+                                      @bind="context.FailureNote"
+                                      placeholder="Optional failure note" />
+                            }
+                        </MudTd>
+                        <MudTd DataLabel="Delete">
+                            <button class="btn btn-sm btn-danger" @onclick="@(() => HandleAttemptDeleted(context))">
+                                Delete
+                            </button>
+                        </MudTd>
+                    </RowTemplate>
+                    <PagerContent>
+                        <MudTablePager/>
+                    </PagerContent>
+                </MudTable>
+                break; 
+            case true:
+                <MudTable @ref="_partTable"
+                          ServerData="LoadParts"
+                          Height="250px"
+                          Loading="@IsLoading"
+                          Class="border rounded-3 pt-1"
+                          TableClass="fixed-header-cell table table-striped">
+                    <ColGroup>
+                        <col style="width: 45%"/>
+                        <col/>
+                        <col/>
+                    </ColGroup>
+                    <HeaderContent>
+                        <MudTh>Part Name</MudTh>
+                        <MudTh>Part Number</MudTh>
+                        <MudTh>Delete</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="Part Name">
+                            <input type="text"
+                                   class="form-control form-control-sm"
+                                   @bind="context.PartDefinition!.Name"
+                                   placeholder="Part Name" />
+                        </MudTd>
+                        <MudTd DataLabel="Part Number">
+                            <input type="text"
+                                   class="form-control form-control-sm"
+                                   @bind="context.PartDefinition!.Number"
+                                   placeholder="Part Number" />
+                        </MudTd>
+                        <MudTd DataLabel="Delete">
+                            <button class="btn btn-sm btn-danger">
+                                Delete
+                            </button>
+                        </MudTd>
+                    </RowTemplate>
+                    <PagerContent>
+                        <MudTablePager/>
+                    </PagerContent>
+                </MudTable>
+                break;
+        }
     }
     else
     {
@@ -147,6 +200,8 @@
     private bool IsLoading { get; set; } = true;
     
     private bool ShowPersonalInfo => Content.Item2;
+
+    private bool showParts = false;
     
     /// <summary>
     ///  References this dialog while it's being displayed
@@ -155,14 +210,15 @@
     public FluentDialog Dialog { get; set; } = default!;
     
     private IEnumerable<StepAttemptDetailDTO> pagedData = new List<StepAttemptDetailDTO>();
-    private MudTable<StepAttemptDetailDTO> table = new();
+    private MudTable<StepAttemptDetailDTO> stepTable = new();
+    private MudTable<SerializablePart> _partTable = new();
     private int totalItems;
 
     /// <inheritdoc />
     protected override async Task OnInitializedAsync()
     {
         await GrabServerData();
-        await table.ReloadServerData();
+        await stepTable.ReloadServerData();
     }
 
     private async Task GrabServerData()
@@ -185,6 +241,22 @@
         totalItems = data.Count();
         pagedData = data.Skip(state.Page * state.PageSize).Take(state.PageSize).ToArray();
         return new TableData<StepAttemptDetailDTO>() {TotalItems = totalItems, Items = pagedData};
+    }
+    
+    private async Task<TableData<SerializablePart>> LoadParts(
+        TableState state, CancellationToken token)
+    {
+        var data = shownLog.InstalledParts ?? Enumerable.Empty<SerializablePart>();
+
+        await Task.Delay(20, token);
+
+        return new TableData<SerializablePart>
+        {
+            TotalItems = data.Count(),
+            Items = data.Skip(state.Page * state.PageSize)
+                .Take(state.PageSize)
+                .ToList()
+        };
     }
     
     private async Task SaveAsync()
@@ -264,11 +336,24 @@
         shownAttempts.Remove(attempt);
 
         // Reload table
-        await table.ReloadServerData();
+        await stepTable.ReloadServerData();
 
-        if (!table.FilteredItems.Any())
+        if (!stepTable.FilteredItems.Any())
         {
             ToastService.ShowWarning("All attempts removed. Saving will now delete this log.");
         }
+    }
+
+    /*
+    private async Task HandlePartDeleted(SerializablePart part)
+    {
+        
+    }
+    */
+    
+    private void ToggleParts()
+    {
+        showParts = !showParts;
+        StateHasChanged();
     }
 }

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLog/CreateHeader.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLog/CreateHeader.razor
@@ -21,11 +21,10 @@
                min="1" />
     </div>
     
-    @*
     <button class="btn btn-primary btn-sm me-4" @onclick="OpenReworkDialog">
         <i class="bi bi-wrench me-1"></i>Rework Parts
     </button>
-    *@
+    
 </div>
 
 @if (!string.IsNullOrWhiteSpace(ActiveLineOperator))

--- a/MESS/MESS.Services/CRUD/ProductionLogs/ProductionLogService.cs
+++ b/MESS/MESS.Services/CRUD/ProductionLogs/ProductionLogService.cs
@@ -327,9 +327,13 @@ public class ProductionLogService : IProductionLogService
             // Load produced part separately (NO tracking)
             var producedPart = await _serializablePartService
                 .GetProducedForProductionLogAsync(log.Id);
+            
+            var installedParts = await _serializablePartService
+                .GetInstalledForProductionLogAsync(log.Id);
 
             dto.ProducedPartName = producedPart?.PartDefinition?.Name;
             dto.ProducedPartSerialNumber = producedPart?.SerialNumber;
+            dto.InstalledParts = installedParts;
 
             return dto;
         }

--- a/MESS/MESS.Services/CRUD/ProductionLogs/ProductionLogService.cs
+++ b/MESS/MESS.Services/CRUD/ProductionLogs/ProductionLogService.cs
@@ -1,4 +1,5 @@
 ﻿using MESS.Data.Context;
+using MESS.Services.CRUD.SerializableParts;
 using MESS.Services.DTOs.ProductionLogs.Batch;
 using MESS.Services.DTOs.ProductionLogs.CreateRequest;
 using MESS.Services.DTOs.ProductionLogs.Detail;
@@ -15,13 +16,18 @@ using Data.Models;
 public class ProductionLogService : IProductionLogService
 {
     private readonly IDbContextFactory<ApplicationContext> _contextFactory;
+    private readonly ISerializablePartService _serializablePartService;
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="ProductionLogService"/> class.
     /// </summary>
     /// <param name="contextFactory">The application database context used for accessing production logs.</param>
-    public ProductionLogService(IDbContextFactory<ApplicationContext> contextFactory)
+    /// <param name="serializablePartService">The service for managing serializable parts.</param>
+    /// <remarks>The SerializablePartService is used here for loading the ProductionLogDetailDTO.</remarks>
+    public ProductionLogService(IDbContextFactory<ApplicationContext> contextFactory, ISerializablePartService serializablePartService)
     {
         _contextFactory = contextFactory;
+        _serializablePartService = serializablePartService;
     }
     
     /// <inheritdoc />
@@ -307,11 +313,25 @@ public class ProductionLogService : IProductionLogService
                 .ThenInclude(ls => ls.Attempts)
                 .FirstOrDefaultAsync(p => p.Id == id);
 
-            if (log != null) return log.ToDetailDTO();
-            Log.Warning("ProductionLog with ID {LogId} not found in GetDetailByIdAsync.", id);
-            return null;
+            if (log is null)
+            {
+                Log.Warning(
+                    "ProductionLog with ID {LogId} not found in GetDetailByIdAsync.",
+                    id);
+                return null;
+            }
 
-            // Map to DTO for UI consumption
+            // Map core log → DTO
+            var dto = log.ToDetailDTO();
+
+            // Load produced part separately (NO tracking)
+            var producedPart = await _serializablePartService
+                .GetProducedForProductionLogAsync(log.Id);
+
+            dto.ProducedPartName = producedPart?.PartDefinition?.Name;
+            dto.ProducedPartSerialNumber = producedPart?.SerialNumber;
+
+            return dto;
         }
         catch (Exception ex)
         {

--- a/MESS/MESS.Services/CRUD/SerializableParts/SerializablePartService.cs
+++ b/MESS/MESS.Services/CRUD/SerializableParts/SerializablePartService.cs
@@ -266,7 +266,7 @@ public class SerializablePartService : ISerializablePartService
 
         await using var context = await _contextFactory.CreateDbContextAsync();
 
-        var query =
+        var results = await (
             from plp in context.ProductionLogParts.AsNoTracking()
             where productionLogIds.Contains(plp.ProductionLogId)
                   && plp.OperationType == PartOperationType.Installed
@@ -275,11 +275,8 @@ public class SerializablePartService : ISerializablePartService
             select new InstalledPartResult(
                 plp.ProductionLogId,
                 plp.SerializablePart!
-            );
-
-        var results = await query
-            .Include(r => r.Part.PartDefinition)
-            .ToListAsync();
+            )
+        ).ToListAsync();
 
         return results;
     }

--- a/MESS/MESS.Services/DTOs/ProductionLogs/Detail/ProductionLogDetailDTO.cs
+++ b/MESS/MESS.Services/DTOs/ProductionLogs/Detail/ProductionLogDetailDTO.cs
@@ -48,6 +48,18 @@ public class ProductionLogDetailDTO
     /// May be <c>null</c> if the log has never been modified after creation.
     /// </summary>
     public string? LastModifiedBy { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the name of the part produced by this production log.
+    /// <c>null</c> if no produced part is associated.
+    /// </summary>
+    public string? ProducedPartName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the serial number of the produced part.
+    /// <c>null</c> if the produced part has no serial number or does not exist.
+    /// </summary>
+    public string? ProducedPartSerialNumber { get; set; }
 
     /// <summary>
     /// Gets or sets all step attempts in the log, each including associated step metadata.

--- a/MESS/MESS.Services/DTOs/ProductionLogs/Detail/ProductionLogDetailDTO.cs
+++ b/MESS/MESS.Services/DTOs/ProductionLogs/Detail/ProductionLogDetailDTO.cs
@@ -1,3 +1,4 @@
+using MESS.Data.Models;
 using MESS.Services.DTOs.ProductionLogs.LogSteps.Attempts.Detail;
 
 namespace MESS.Services.DTOs.ProductionLogs.Detail;
@@ -66,4 +67,9 @@ public class ProductionLogDetailDTO
     /// This collection is flattened for display and editing purposes.
     /// </summary>
     public List<StepAttemptDetailDTO> Attempts { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets all installed parts from a production log. This collection is flattened for display and editing purposes.
+    /// </summary>
+    public List<SerializablePart> InstalledParts { get; set; } = [];
 }

--- a/MESS/MESS.Services/UI/PartTraceability/PartTraceabilityService.cs
+++ b/MESS/MESS.Services/UI/PartTraceability/PartTraceabilityService.cs
@@ -227,508 +227,241 @@ public class PartTraceabilityService : IPartTraceabilityService
         }
     }
     
-    /// <summary>
-    /// Persists in-memory part traceability entries into the database.
-    /// For each group (logIndex) the corresponding savedLogs[logIndex].Id is used
-    /// as the ProductionLogId for created ProductionLogPart records.
-    /// </summary>
+    /// <inheritdoc />
     public async Task<bool> PersistAsync(List<ProductionLogFormDTO> savedLogs)
     {
         ArgumentNullException.ThrowIfNull(savedLogs);
 
         var partsToCreate = new List<ProductionLogPart>();
-
-        // Determine whether we have a snapshot (Scenario 2) or not (Scenario 1)
         var hasSnapshot = _snapshotGroups.Count > 0;
 
-        // Iterate through current groups (these are the logs we're saving)
         foreach (var group in _entryGroups.Values)
         {
             var logIndex = group.LogIndex;
 
-            // Validate mapping to savedLogs
             if (logIndex < 0 || logIndex >= savedLogs.Count)
-            {
-                Log.Warning("No saved production log for log index {LogIndex}; skipping persistence for this group.", logIndex);
                 continue;
-            }
 
             var savedLogId = savedLogs[logIndex].Id;
             if (savedLogId <= 0)
-            {
-                Log.Warning("Saved production log at index {LogIndex} has invalid Id {Id}; skipping group.", logIndex, savedLogId);
                 continue;
+
+            _snapshotGroups.TryGetValue(logIndex, out var snapshot);
+
+            if (snapshot != null)
+            {
+                await IdentifySnapshotChangesAsync(
+                    group,
+                    snapshot,
+                    savedLogId,
+                    partsToCreate);
+            }
+            else
+            {
+                await IdentifyInitialInstallsAsync(
+                    group,
+                    savedLogId,
+                    partsToCreate);
             }
 
-            // find snapshot group if present
-            _snapshotGroups.TryGetValue(logIndex, out var snapshotGroup);
-
-            // Build quick lookup of snapshot entries by PartNodeId
-            var snapshotEntriesByNode = (snapshotGroup?.PartNodeEntries ?? [])
-                .ToDictionary(e => e.PartNodeId, e => e);
-
-            // For each entry in current group, decide actions
-            foreach (var entry in group.PartNodeEntries)
-            {
-                var currentSerial = entry.SerializablePart;
-                var currentLinkedLog = entry.LinkedProductionLog;
-
-                snapshotEntriesByNode.TryGetValue(entry.PartNodeId, out var snapshotEntry);
-                var snapshotSerial = snapshotEntry?.SerializablePart;
-                var snapshotLinked = snapshotEntry?.LinkedProductionLog;
-
-                // ---------- SNAPSHOT MODE ----------
-                if (hasSnapshot && snapshotEntry != null)
-                {
-                    // 1) Snapshot had a serial and current has no entry => REMOVED
-                    if (snapshotSerial != null && currentSerial == null && currentLinkedLog == null)
-                    {
-                        // Removed: use snapshotSerial.Id
-                        partsToCreate.Add(BuildRemovedPart(savedLogId, snapshotSerial));
-                        Log.Information("Detected removal (snapshot serial existed, now empty) for node {NodeId} in logIndex {LogIndex}.", entry.PartNodeId, logIndex);
-                        continue;
-                    }
-
-                    // 2) Snapshot had a linked production log and current is now empty => REMOVED (resolve produced via linked)
-                    if (snapshotLinked != null && currentSerial == null && currentLinkedLog == null)
-                    {
-                        try
-                        {
-                            var produced = await _serializablePartService.GetProducedForProductionLogAsync(snapshotLinked.Id);
-                            if (produced != null)
-                            {
-                                partsToCreate.Add(BuildRemovedPart(savedLogId, produced));
-                                Log.Information("Detected removal of part produced in prior log {PriorLogId} for node {NodeId} in logIndex {LogIndex}.", snapshotLinked.Id, entry.PartNodeId, logIndex);
-                            }
-                            else
-                            {
-                                Log.Warning("Snapshot linked log {PriorLogId} could not be resolved to a produced part; cannot produce removal entry.", snapshotLinked.Id);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Warning(ex, "Error resolving produced part for linked snapshot log {LinkedLogId}.", snapshotLinked.Id);
-                        }
-
-                        continue;
-                    }
-
-                    // 3) Snapshot had a serial and current has a different serial => Removed(old) + Installed(new)
-                    if (snapshotSerial != null && currentSerial != null && snapshotSerial.Id != currentSerial.Id)
-                    {
-                        // Removed old
-                        partsToCreate.Add(BuildRemovedPart(savedLogId, snapshotSerial));
-                        Log.Information("Replacing serial for node {NodeId} in logIndex {LogIndex}: removed old serial {OldSerial}.", entry.PartNodeId, logIndex, snapshotSerial.SerialNumber);
-
-                        // Installed new — but ensure we have a persisted SerializablePart (attempt reuse if same serial exists)
-                        var installedPart = currentSerial;
-                        if (currentSerial.Id <= 0)
-                        {
-                            // The currentSerial in memory may not be in DB; attempt to check/create
-                            try
-                            {
-                                // If serial string provided, try to create or fetch
-                                if (!string.IsNullOrWhiteSpace(currentSerial.SerialNumber))
-                                {
-                                    var serialStr = currentSerial.SerialNumber!;
-                                    var defId = currentSerial.PartDefinitionId;
-
-                                    // Prefer to fetch existing if present
-                                    var exists = await _serializablePartService.ExistsAsync(defId, serialStr);
-                                    if (exists)
-                                    {
-                                        var existing = await _serializablePartService.GetBySerialNumberAsync(serialStr);
-                                        if (existing != null)
-                                            installedPart = existing;
-                                        else
-                                            Log.Warning("ExistsAsync returned true but GetBySerialNumberAsync returned null for serial {Serial}. Creating new.", serialStr);
-                                    }
-                                    else
-                                    {
-                                        var created = await _serializablePartService.CreateAsync(currentSerial.PartDefinition!, serialStr);
-                                        if (created != null)
-                                            installedPart = created;
-                                        else
-                                            Log.Warning("Failed to create SerializablePart for replacement serial {Serial}.", serialStr);
-                                    }
-                                }
-                                else
-                                {
-                                    // No serial string: nothing to install
-                                    Log.Debug("Replacement current serial for node {NodeId} lacks SerialNumber; skipping install.", entry.PartNodeId);
-                                    continue;
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Warning(ex, "Error resolving/creating serializable part for replacement in node {NodeId}.", entry.PartNodeId);
-                                continue;
-                            }
-                        }
-
-                        // Add installed entry
-                        partsToCreate.Add(BuildInstalledPart(savedLogId, installedPart));
-                        continue;
-                    }
-
-                    // 4) Snapshot had a linked production log and current has a different linked or a serial => handle removal + optional install
-                    if (snapshotLinked != null)
-                    {
-                        var snapshotLinkedId = snapshotLinked.Id;
-
-                        // If still linked to same prior log => nothing to do
-                        if (currentLinkedLog != null && currentLinkedLog.Id == snapshotLinkedId)
-                        {
-                            // Unchanged - nothing to do
-                            continue;
-                        }
-
-                        // Otherwise the snapshot linked item was removed or replaced -> create Removed for the snapshot produced part
-                        try
-                        {
-                            var produced = await _serializablePartService.GetProducedForProductionLogAsync(snapshotLinkedId);
-                            if (produced != null)
-                            {
-                                partsToCreate.Add(BuildRemovedPart(savedLogId, produced));
-                                Log.Information("Snapshot referenced linked log {LinkedId} for node {NodeId}; creating Removed entry.", snapshotLinkedId, entry.PartNodeId);
-                            }
-                            else
-                            {
-                                Log.Warning("Snapshot linked production log {LinkedId} could not be resolved to a produced part; skipping removal entry.", snapshotLinkedId);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Warning(ex, "Error resolving produced part for snapshot linked log {LinkedId}.", snapshotLinkedId);
-                        }
-
-                        // If new current is a serial -> create Installed for it (resolve/create as needed)
-                        if (currentSerial != null)
-                        {
-                            SerializablePart installedPart = currentSerial;
-                            if (currentSerial.Id <= 0)
-                            {
-                                try
-                                {
-                                    var serialStr = currentSerial.SerialNumber!;
-                                    var defId = currentSerial.PartDefinitionId;
-
-                                    var exists = await _serializablePartService.ExistsAsync(defId, serialStr);
-                                    if (exists)
-                                    {
-                                        var existing = await _serializablePartService.GetBySerialNumberAsync(serialStr);
-                                        if (existing != null)
-                                            installedPart = existing;
-                                        else
-                                            Log.Warning("ExistsAsync true but GetBySerialNumberAsync returned null for serial {Serial}. Creating new.", serialStr);
-                                    }
-                                    else
-                                    {
-                                        var created = await _serializablePartService.CreateAsync(currentSerial.PartDefinition!, serialStr);
-                                        if (created != null)
-                                            installedPart = created;
-                                        else
-                                            Log.Warning("Failed to create SerializablePart for serial {Serial}.", serialStr);
-                                    }
-                                }
-                                catch (Exception ex)
-                                {
-                                    Log.Warning(ex, "Error resolving/creating serializable part for node {NodeId}.", entry.PartNodeId);
-                                    continue;
-                                }
-                            }
-
-                            partsToCreate.Add(BuildInstalledPart(savedLogId, installedPart));
-                        }
-
-                        continue;
-                    }
-
-                    // 5) Snapshot had serial and current is still same -> do nothing
-                    if (snapshotSerial != null && currentSerial != null && snapshotSerial.Id == currentSerial.Id)
-                    {
-                        // unchanged — do nothing
-                        continue;
-                    }
-
-                    // 6) Snapshot empty but current has serial or linked — handled below in non-snapshot path
-                }
-
-                // ---------- NO SNAPSHOT (Scenario 1) or case fell through ----------
-                if (!hasSnapshot)
-                {
-                    // Try to determine which part to install
-                    SerializablePart? partToInstall = null;
-
-                    // 1) If current serial exists and already has an Id (pre-produced), install it
-                    if (currentSerial != null && currentSerial.Id > 0)
-                    {
-                        partToInstall = currentSerial;
-                        Log.Information("Scenario1: installing pre-produced part {Id} for node {NodeId}", currentSerial.Id, entry.PartNodeId);
-                    }
-                    // 2) If current serial exists and has a serial number, resolve/create as usual
-                    else if (currentSerial != null && !string.IsNullOrWhiteSpace(currentSerial.SerialNumber))
-                    {
-                        try
-                        {
-                            if (currentSerial.PartDefinition == null)
-                            {
-                                Log.Warning("Scenario1: currentSerial.PartDefinition is null for node {NodeId}", entry.PartNodeId);
-                            }
-                            else
-                            {
-                                var exists = await _serializablePartService.ExistsAsync(currentSerial.PartDefinitionId, currentSerial.SerialNumber!);
-                                if (exists)
-                                {
-                                    partToInstall = await _serializablePartService.GetBySerialNumberAsync(currentSerial.SerialNumber!) 
-                                                    ?? await _serializablePartService.CreateAsync(currentSerial.PartDefinition, currentSerial.SerialNumber!);
-                                }
-                                else
-                                {
-                                    partToInstall = await _serializablePartService.CreateAsync(currentSerial.PartDefinition, currentSerial.SerialNumber!);
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Warning(ex, "Scenario1: error resolving/creating serial for node {NodeId}", entry.PartNodeId);
-                        }
-                    }
-                    // 3) If no serial, try linked production log
-                    else if (currentLinkedLog != null)
-                    {
-                        partToInstall = await _serializablePartService.GetProducedForProductionLogAsync(currentLinkedLog.Id);
-                    }
-
-                    // 4) Before creating Installed PLP, enforce InputType rules
-                    var nodeInputType = entry.PartNode?.InputType;
-
-                    // SerialNumber nodes require non-null serial
-                    if (nodeInputType == PartInputType.SerialNumber)
-                    {
-                        if (partToInstall == null || string.IsNullOrWhiteSpace(partToInstall.SerialNumber))
-                        {
-                            Log.Information("Skipping Installed PLP for node {NodeId}: SerialNumber-required but null.",
-                                entry.PartNodeId);
-                            continue;
-                        }
-                    }
-
-                    // ProductionLogId nodes do not require serial
-                    if (nodeInputType == PartInputType.ProductionLogId)
-                    {
-                        if (partToInstall == null)
-                        {
-                            Log.Warning("ProductionLogId node {NodeId} had no resolvable SerializablePart.",
-                                entry.PartNodeId);
-                            continue;
-                        }
-                    }
-
-                    // 5) Create Installed PLP
-                    if (partToInstall != null)
-                    {
-                        partsToCreate.Add(BuildInstalledPart(savedLogId, partToInstall));
-                        Log.Information("Created Installed PLP for node {NodeId}, part {PartId}",
-                            entry.PartNodeId, partToInstall.Id);
-                    }
-                    else
-                    {
-                        Log.Warning("Tried to create Installed PLP for node {NodeId} but partToInstall was null.",
-                            entry.PartNodeId);
-                    }
-                    
-                }
-                else
-                {
-                    // We are in snapshot mode but some edge fell through above (e.g., snapshot missing but hasSnapshot true)
-                    // Handle the common cases: if current has a serial and snapshot either didn't have it or it was different (already mostly covered),
-                    // ensure we install the current serial (resolve/create) when needed.
-
-                    // If current has a serial and it wasn't matched above, and wasn't the same as snapshot → install it
-                    if (currentSerial != null)
-                    {
-                        // If it already has an Id (persisted), just create Installed entry
-                        if (currentSerial.Id > 0)
-                        {
-                            partsToCreate.Add(BuildInstalledPart(savedLogId, currentSerial));
-                            Log.Information("Snapshot-mode fallback: adding Installed for existing serial id {Id} for node {NodeId}.", currentSerial.Id, entry.PartNodeId);
-                        }
-                        else
-                        {
-                            try
-                            {
-                                // ---- REQUIRED NULLABILITY GUARDS ----
-                                if (string.IsNullOrWhiteSpace(currentSerial.SerialNumber))
-                                {
-                                    Log.Warning(
-                                        "Snapshot-mode fallback: cannot resolve/create SerializablePart for node {NodeId} because SerialNumber is null or empty.",
-                                        entry.PartNodeId);
-                                    continue;
-                                }
-
-                                if (currentSerial.PartDefinition == null)
-                                {
-                                    Log.Warning(
-                                        "Snapshot-mode fallback: cannot resolve/create SerializablePart for node {NodeId} because PartDefinition is null.",
-                                        entry.PartNodeId);
-                                    continue;
-                                }
-                                // -------------------------------------
-
-                                var serialStr = currentSerial.SerialNumber;
-                                var defId = currentSerial.PartDefinitionId;
-
-                                SerializablePart? installedPart = null;
-
-                                // Try to reuse existing
-                                var exists = await _serializablePartService.ExistsAsync(defId, serialStr);
-                                if (exists)
-                                {
-                                    var existing = await _serializablePartService.GetBySerialNumberAsync(serialStr);
-                                    if (existing != null)
-                                    {
-                                        installedPart = existing;
-                                    }
-                                    else
-                                    {
-                                        Log.Warning(
-                                            "Snapshot fallback: ExistsAsync true but GetBySerialNumberAsync returned null for serial {Serial}. Attempting create.",
-                                            serialStr);
-
-                                        installedPart = await _serializablePartService.CreateAsync(
-                                            currentSerial.PartDefinition,
-                                            serialStr);
-                                    }
-                                }
-                                else
-                                {
-                                    // Create new serializable part
-                                    installedPart = await _serializablePartService.CreateAsync(
-                                        currentSerial.PartDefinition,
-                                        serialStr);
-                                }
-
-                                if (installedPart != null)
-                                {
-                                    partsToCreate.Add(BuildInstalledPart(savedLogId, installedPart));
-                                    Log.Information(
-                                        "Snapshot-mode fallback: created or used serial {Serial} and added Installed for node {NodeId}.",
-                                        serialStr,
-                                        entry.PartNodeId);
-                                }
-                                else
-                                {
-                                    Log.Warning(
-                                        "Snapshot-mode fallback: failed to create/resolve serializable part for node {NodeId}.",
-                                        entry.PartNodeId);
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Warning(ex,
-                                    "Snapshot-mode fallback: exception while resolving/creating serializable part for node {NodeId}.",
-                                    entry.PartNodeId);
-                            }
-                        }
-                    }
-                }
-
-                continue;
-                
-                // Helper local functions for creating ProductionLogPart objects
-                ProductionLogPart BuildRemovedPart(int productionLogIdForThisSavedLog, SerializablePart removedPart)
-                {
-                    return new ProductionLogPart
-                    {
-                        ProductionLogId = productionLogIdForThisSavedLog,
-                        SerializablePartId = removedPart.Id,
-                        SerializablePart = removedPart,
-                        OperationType = PartOperationType.Removed
-                    };
-                }
-                
-                ProductionLogPart BuildInstalledPart(int productionLogIdForThisSavedLog, SerializablePart installedPart)
-                {
-                    return new ProductionLogPart
-                    {
-                        ProductionLogId = productionLogIdForThisSavedLog,
-                        SerializablePartId = installedPart.Id,
-                        SerializablePart = installedPart,
-                        OperationType = PartOperationType.Installed
-                    };
-                }
-            } // foreach entry
-            
-            // Requirement: scenario 2 must re-produce the same serializable part
-            if (snapshotGroup?.ProducedPart != null)
-            {
-                // Force the current produced part to be the snapshot’s produced part
-                group.ProducedPart = snapshotGroup.ProducedPart;
-            }
-            
-            // Handle ProducedPart for this log
-            if (group.ProducedPart != null)
-            {
-                var produced = group.ProducedPart;
-
-                SerializablePart persisted;
-
-                // Create or get serializable part
-                if (produced.Id > 0)
-                {
-                    persisted = produced;
-                }
-                else
-                {
-                    if (produced.PartDefinition == null)
-                    {
-                        Log.Warning("Produced part for log {LogIndex} has no PartDefinition; skipping.", logIndex);
-                        continue;
-                    }
-
-                    persisted = await _serializablePartService.CreateAsync(
-                        produced.PartDefinition, 
-                        produced.SerialNumber
-                    ) ?? throw new Exception("Failed to create produced part.");
-                }
-
-                // Create Installed PLP entry for this produced part
-                partsToCreate.Add(new ProductionLogPart
-                {
-                    ProductionLogId = savedLogId,
-                    SerializablePartId = persisted.Id,
-                    OperationType = PartOperationType.Produced,
-                });
-
-                Log.Information("Persisted produced part for log {LogIndex}, serial {Serial}.",
-                    logIndex, persisted.SerialNumber);
-            }
-        } // foreach group
+            await ProcessProducedPartAsync(
+                group,
+                snapshot,
+                savedLogId,
+                partsToCreate);
+        }
 
         if (partsToCreate.Count == 0)
-        {
-            Log.Information("No ProductionLogPart records to persist after comparison with snapshot/current state.");
             return true;
+
+        try
+        {
+            return await _productionLogPartService.CreateRangeAsync(partsToCreate);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error persisting ProductionLogPart records.");
+            return false;
+        }
+    }
+    
+    private async Task<SerializablePart?> GetOrPersistPartAsync(SerializablePart current)
+    {
+        if (current.Id > 0)
+            return current;
+
+        if (string.IsNullOrWhiteSpace(current.SerialNumber))
+        {
+            Log.Warning("Cannot persist SerializablePart because SerialNumber is null or empty.");
+            return null;
+        }
+
+        if (current.PartDefinition == null)
+        {
+            Log.Warning("Cannot persist SerializablePart because PartDefinition is null.");
+            return null;
         }
 
         try
         {
-            var created = await _productionLogPartService.CreateRangeAsync(partsToCreate);
-            if (!created)
+            var defId = current.PartDefinitionId;
+            var serial = current.SerialNumber;
+
+            if (await _serializablePartService.ExistsAsync(defId, serial))
             {
-                Log.Warning("ProductionLogPartService.CreateRangeAsync returned false.");
-                return false;
+                return await _serializablePartService.GetBySerialNumberAsync(serial)
+                       ?? await _serializablePartService.CreateAsync(current.PartDefinition, serial);
             }
 
-            Log.Information("Persisted {Count} ProductionLogPart records.", partsToCreate.Count);
-            return true;
+            return await _serializablePartService.CreateAsync(current.PartDefinition, serial);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, "Error while persisting ProductionLogPart records.");
-            return false;
+            Log.Warning(ex, "Error resolving or creating SerializablePart for serial {Serial}.", current.SerialNumber);
+            return null;
         }
+    }
+    
+    private static ProductionLogPart CreateOp(
+        int productionLogId,
+        SerializablePart part,
+        PartOperationType type)
+    {
+        return new ProductionLogPart
+        {
+            ProductionLogId = productionLogId,
+            SerializablePartId = part.Id,
+            SerializablePart = part,
+            OperationType = type
+        };
+    }
+    
+    private async Task IdentifySnapshotChangesAsync(
+        PartEntryGroup group,
+        PartEntryGroup snapshot,
+        int savedLogId,
+        List<ProductionLogPart> partsToCreate)
+    {
+        var snapshotByNode = snapshot.PartNodeEntries
+            .ToDictionary(e => e.PartNodeId);
+
+        foreach (var entry in group.PartNodeEntries)
+        {
+            snapshotByNode.TryGetValue(entry.PartNodeId, out var snap);
+
+            var currentSerial = entry.SerializablePart;
+            var currentLinked = entry.LinkedProductionLog;
+
+            var snapshotSerial = snap?.SerializablePart;
+            var snapshotLinked = snap?.LinkedProductionLog;
+
+            // Snapshot serial removed
+            if (snapshotSerial != null && currentSerial == null && currentLinked == null)
+            {
+                partsToCreate.Add(CreateOp(savedLogId, snapshotSerial, PartOperationType.Removed));
+                continue;
+            }
+
+            // Snapshot linked log removed
+            if (snapshotLinked != null && currentSerial == null && currentLinked == null)
+            {
+                var produced = await _serializablePartService
+                    .GetProducedForProductionLogAsync(snapshotLinked.Id);
+
+                if (produced != null)
+                    partsToCreate.Add(CreateOp(savedLogId, produced, PartOperationType.Removed));
+
+                continue;
+            }
+
+            // Replacement: serial changed
+            if (snapshotSerial != null &&
+                currentSerial != null &&
+                snapshotSerial.Id != currentSerial.Id)
+            {
+                partsToCreate.Add(CreateOp(savedLogId, snapshotSerial, PartOperationType.Removed));
+
+                var installed = await GetOrPersistPartAsync(currentSerial);
+                if (installed != null)
+                    partsToCreate.Add(CreateOp(savedLogId, installed, PartOperationType.Installed));
+
+                continue;
+            }
+
+            // Replacement: linked log changed
+            if (snapshotLinked != null &&
+                (currentLinked == null || currentLinked.Id != snapshotLinked.Id))
+            {
+                var produced = await _serializablePartService
+                    .GetProducedForProductionLogAsync(snapshotLinked.Id);
+
+                if (produced != null)
+                    partsToCreate.Add(CreateOp(savedLogId, produced, PartOperationType.Removed));
+
+                if (currentSerial != null)
+                {
+                    var installed = await GetOrPersistPartAsync(currentSerial);
+                    if (installed != null)
+                        partsToCreate.Add(CreateOp(savedLogId, installed, PartOperationType.Installed));
+                }
+            }
+        }
+    }
+    
+    private async Task IdentifyInitialInstallsAsync(
+        PartEntryGroup group,
+        int savedLogId,
+        List<ProductionLogPart> partsToCreate)
+    {
+        foreach (var entry in group.PartNodeEntries)
+        {
+            SerializablePart? part = null;
+
+            if (entry.SerializablePart != null)
+            {
+                part = await GetOrPersistPartAsync(entry.SerializablePart);
+            }
+            else if (entry.LinkedProductionLog != null)
+            {
+                part = await _serializablePartService
+                    .GetProducedForProductionLogAsync(entry.LinkedProductionLog.Id);
+            }
+
+            var inputType = entry.PartNode?.InputType;
+
+            if (inputType == PartInputType.SerialNumber &&
+                (part == null || string.IsNullOrWhiteSpace(part.SerialNumber)))
+                continue;
+
+            if (inputType == PartInputType.ProductionLogId && part == null)
+                continue;
+
+            if (part != null)
+            {
+                partsToCreate.Add(CreateOp(savedLogId, part, PartOperationType.Installed));
+            }
+        }
+    }
+    
+    private async Task ProcessProducedPartAsync(
+        PartEntryGroup group,
+        PartEntryGroup? snapshot,
+        int savedLogId,
+        List<ProductionLogPart> partsToCreate)
+    {
+        if (snapshot?.ProducedPart != null)
+        {
+            group.ProducedPart = snapshot.ProducedPart;
+        }
+
+        if (group.ProducedPart == null)
+            return;
+
+        var persisted = await GetOrPersistPartAsync(group.ProducedPart);
+        if (persisted == null)
+            return;
+
+        partsToCreate.Add(CreateOp(savedLogId, persisted, PartOperationType.Produced));
     }
     
     /// <inheritdoc />

--- a/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
+++ b/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
@@ -324,32 +324,31 @@ public class WorkInstructionEditorService : IWorkInstructionEditorService
         if (Current == null)
             return false;
 
-        // Resolve the PartDefinition
+        // Resolve the produced part name → PartDefinition
         if (!string.IsNullOrWhiteSpace(_pendingProducedPartName))
         {
-            var part = await _partDefinitionService.GetOrCreateByNameAsync(_pendingProducedPartName);
+            var part = await _partDefinitionService
+                .GetOrCreateByNameAsync(_pendingProducedPartName);
+
             if (part != null)
             {
                 Current.PartProduced = part;
                 Current.PartProducedId = part.Id;
             }
 
-            _pendingProducedPartName = null; // reset after save
+            _pendingProducedPartName = null;
         }
-        
-        bool success = false;
+
+        bool success;
 
         switch (Mode)
         {
             case EditorMode.CreateNew:
                 Current.OriginalId = null;
-                Current.IsLatest = true;
                 success = await _workInstructionService.Create(Current);
-                Mode = EditorMode.EditExisting;
                 break;
 
             case EditorMode.EditExisting:
-                Current.IsLatest = true;
                 success = await _workInstructionService.UpdateWorkInstructionAsync(Current);
                 break;
 
@@ -357,44 +356,49 @@ public class WorkInstructionEditorService : IWorkInstructionEditorService
                 if (Current.OriginalId == null)
                     throw new InvalidOperationException("OriginalId is required for versioning.");
 
-                await _workInstructionService.MarkAllVersionsNotLatestAsync(Current.OriginalId.Value);
-                Current.IsLatest = true;
-                success = await _workInstructionService.Create(Current);
+                success = await _workInstructionService.CreateNewVersionAsync(Current);
                 break;
+
+            default:
+                return false;
         }
-        if (Current != null)
+
+        if (!success)
+            return false;
+
+        // -----------------------------
+        // Post-commit editor state only
+        // -----------------------------
+
+        if (Current.IsActive)
         {
-            if (success && Current.IsActive)
+            await _workInstructionService.MarkOtherVersionsInactiveAsync(Current.Id);
+        }
+
+        IsDirty = false;
+        Mode = EditorMode.EditExisting;
+        NotifyChanged();
+
+        // Cleanup queued deletions AFTER a successful save
+        if (_nodesQueuedForDeletion.Any())
+        {
+            var deleted = await _workInstructionService.DeleteNodesAsync(_nodesQueuedForDeletion);
+            if (deleted)
             {
-                await _workInstructionService.MarkOtherVersionsInactiveAsync(Current.Id);
+                _nodesQueuedForDeletion.Clear();
             }
-        }
-        else
-        {
-            Log.Warning("Current Work Instruction in editor is null.");
-        }
-        if (success)
-        {
-            IsDirty = false;
-            NotifyChanged();
-            
-            // after saving Current, delete nodes to prevent orphaning
-            if (_nodesQueuedForDeletion.Any())
+            else
             {
-                var deleted = await _workInstructionService.DeleteNodesAsync(_nodesQueuedForDeletion);
-                if (deleted)
-                {
-                    _nodesQueuedForDeletion.Clear();
-                }
-                else
-                {
-                    // handle failure to delete nodes, maybe log warning or throw
-                }
+                Log.Warning(
+                    "Failed to delete {Count} queued nodes after saving WorkInstruction {Id}",
+                    _nodesQueuedForDeletion.Count,
+                    Current.Id);
             }
         }
 
-        return success;
+        return true;
     }
+
 
     /// <inheritdoc />
     public void Reset()

--- a/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
+++ b/MESS/MESS.Services/UI/WorkInstructionEditor/WorkInstructionEditorService.cs
@@ -230,6 +230,7 @@ public class WorkInstructionEditorService : IWorkInstructionEditorService
             IsLatest = true,
             ShouldGenerateQrCode = template.ShouldGenerateQrCode,
             PartProducedIsSerialized = template.PartProducedIsSerialized,
+            PartProduced = template.PartProduced,
             Products = template.Products?.ToList() ?? new List<Product>(),
             Nodes = await CloneNodesAsync(template.Nodes)
         };

--- a/MESS/MESS.Tests/Services/ProductionLogServiceTests.cs
+++ b/MESS/MESS.Tests/Services/ProductionLogServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using MESS.Data.Models;
+using MESS.Services.CRUD.SerializableParts;
 
 namespace MESS.Tests.Services;
 
@@ -34,6 +35,8 @@ public class ProductionLogServiceTests : IDisposable
     private ProductionLogService CreateService()
     {
         var dbFactory = new Mock<IDbContextFactory<ApplicationContext>>();
+        var mockSerializablePartService = new Mock<ISerializablePartService>();
+        
         dbFactory.Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
@@ -42,7 +45,7 @@ public class ProductionLogServiceTests : IDisposable
                 return ctx;
             });
 
-        return new ProductionLogService(dbFactory.Object);
+        return new ProductionLogService(dbFactory.Object, mockSerializablePartService.Object);
     }
 
     private static async Task<(int productId, int workInstructionId)> SeedProductAndWIAsync(string wiTitle, DbContextOptions<ApplicationContext> options)


### PR DESCRIPTION
This pull request features a significant refactoring of the core part traceability logic within MESS. In theory, it should behave the same as before, the code is just far more readable. 

**Bug Fix**
Operators can now see serial numbers from produced parts as before the large part traceability database migration.