### PR TITLE
Minor Work Instruction Saving Tweaks + New Page Titles

### DIFF
--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/Product/Index.razor
@@ -14,7 +14,7 @@
 @inject IWorkInstructionService WorkInstructionService
 @inject IToastService ToastService
 
-<PageTitle>Product List</PageTitle>
+<PageTitle>Products</PageTitle>
 
 @if (Products.Count == 0)
 {

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/UserManagement/OperatorManager.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/UserManagement/OperatorManager.razor
@@ -14,9 +14,11 @@
 @inject UserManager<ApplicationUser> UserManager
 @inject IToastService ToastService
 
+<PageTitle>Users</PageTitle>
+
 <div class="container justify-content-center">
     <h1 class="mb-4">
-        Operators
+        Users
     </h1>
     @* <button class="btn btn-primary" @onclick="SaveChanges">Save Changes</button> *@
     

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionManager.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/WorkInstructionManager.razor
@@ -26,6 +26,8 @@
 
 @attribute [Authorize(Roles = "Technician, Administrator")]
 
+<PageTitle>Work Instruction Editor</PageTitle>
+
 <MenuBarPhoebe 
     Products="@AllProducts"
     WorkInstructions="@FilteredWorkInstructions"

--- a/MESS/MESS.Blazor/Components/Pages/ProductionLogEditor/ProductionLogList.razor
+++ b/MESS/MESS.Blazor/Components/Pages/ProductionLogEditor/ProductionLogList.razor
@@ -14,7 +14,7 @@
 @inject AuthenticationStateProvider AuthProvider
 @inject NavigationManager NavManager
 
-<PageTitle>Production Logs</PageTitle>
+<PageTitle>My Production Logs</PageTitle>
 
 <ErrorBoundary>
     <ChildContent>

--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
@@ -497,7 +497,7 @@ public class WorkInstructionService : IWorkInstructionService
                 context.Entry(partNode.PartDefinition).State = EntityState.Unchanged;
             }
             
-            workInstruction.IsActive = false;
+            workInstruction.IsActive = true;
             await context.WorkInstructions.AddAsync(workInstruction);
             await context.SaveChangesAsync();
             
@@ -571,9 +571,9 @@ public class WorkInstructionService : IWorkInstructionService
                 }
             }
 
-            // Default new WorkInstructions to inactive
-            workInstruction.IsActive = false;
-            workInstruction.IsLatest = false;
+            // Default new WorkInstructions to active and latest since this is a new creation (not a version update)
+            workInstruction.IsActive = true;
+            workInstruction.IsLatest = true;
 
             await context.WorkInstructions.AddAsync(workInstruction);
             await context.SaveChangesAsync();


### PR DESCRIPTION
## Bug Fixes
This small pull request fixes a potential bug with creating new work instructions. Before, new work instructions would be initially set to no the latest in their version chain, leading to the chance of them being hidden instantly after creation. 

## New Quality of Life Feature
When creating or updating a work instruction, it should always remain active. No need to manually set your work instruction as active after updating. Eventually, whether this feature is available or not will depend on a global configuration rather than being hardcoded.

Page titles have also been added to a number of pages without them. Other page titles have been changed to be more clear.  All of these page titles render on the browser tab title.