### PR TITLE
Fixing Part Traceability View Query Error

### DIFF
--- a/MESS/MESS.Data/Migrations/20260309162654_UpdateTraceabilityViewForNoParentId.Designer.cs
+++ b/MESS/MESS.Data/Migrations/20260309162654_UpdateTraceabilityViewForNoParentId.Designer.cs
@@ -4,6 +4,7 @@ using MESS.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace MESS.Data.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20260309162654_UpdateTraceabilityViewForNoParentId")]
+    partial class UpdateTraceabilityViewForNoParentId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MESS/MESS.Data/Migrations/20260309162654_UpdateTraceabilityViewForNoParentId.cs
+++ b/MESS/MESS.Data/Migrations/20260309162654_UpdateTraceabilityViewForNoParentId.cs
@@ -1,0 +1,86 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MESS.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateTraceabilityViewForNoParentId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID('dbo.TraceabilityView', 'V') IS NOT NULL
+                    DROP VIEW dbo.TraceabilityView;
+            ");
+            
+            migrationBuilder.Sql(@"
+                EXEC('
+                    CREATE VIEW dbo.TraceabilityView AS
+                    SELECT
+                    pDef.Name AS Product,
+                        pl.CreatedOn AS SubmitTime,
+                        partDef.Name AS PartName,
+                        partDef.Number AS PartNumber,
+                        sp.SerialNumber AS PartSerialNumber,
+                        CASE plp.OperationType
+                            WHEN 0 THEN ''Installed''
+                            WHEN 1 THEN ''Produced''
+                            WHEN 2 THEN ''Removed''
+                        END AS OperationType,
+                        u.FirstName,
+                        u.LastName,
+                        u.UserName
+                            FROM dbo.ProductionLogParts AS plp
+                            INNER JOIN dbo.ProductionLogs AS pl ON plp.ProductionLogId = pl.Id
+                        INNER JOIN dbo.Products AS p ON pl.ProductId = p.Id
+                        INNER JOIN dbo.PartDefinitions AS pDef ON p.PartDefinitionId = pDef.Id
+                        LEFT JOIN dbo.SerializableParts AS sp ON plp.SerializablePartId = sp.Id
+                        LEFT JOIN dbo.PartDefinitions AS partDef ON sp.PartDefinitionId = partDef.Id
+                        LEFT JOIN dbo.AspNetUsers AS u ON pl.OperatorId = u.Id
+                ');
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF OBJECT_ID('dbo.TraceabilityView', 'V') IS NOT NULL
+                    DROP VIEW dbo.TraceabilityView;
+            ");
+
+            migrationBuilder.Sql(@"
+                EXEC('
+                    CREATE VIEW dbo.TraceabilityView AS
+                    SELECT
+                        pDef.Name AS Product,
+                        pl.CreatedOn AS SubmitTime,
+                        partDef.Name AS PartName,
+                        partDef.Number AS PartNumber,
+                        sp.SerialNumber AS PartSerialNumber,
+                        parentDef.Name AS ParentPartName,
+                        parentSp.SerialNumber AS ParentSerialNumber,
+                        CASE plp.OperationType
+                            WHEN 0 THEN ''Installed''
+                            WHEN 1 THEN ''Produced''
+                            WHEN 2 THEN ''Removed''
+                        END AS OperationType,
+                        u.FirstName,
+                        u.LastName,
+                        u.UserName
+                    FROM dbo.ProductionLogParts AS plp
+                    INNER JOIN dbo.ProductionLogs AS pl ON plp.ProductionLogId = pl.Id
+                    INNER JOIN dbo.Products AS p ON pl.ProductId = p.Id
+                    INNER JOIN dbo.PartDefinitions AS pDef ON p.PartDefinitionId = pDef.Id
+                    LEFT JOIN dbo.SerializableParts AS sp ON plp.SerializablePartId = sp.Id
+                    LEFT JOIN dbo.PartDefinitions AS partDef ON sp.PartDefinitionId = partDef.Id
+                    LEFT JOIN dbo.SerializableParts AS parentSp ON plp.ParentPartId = parentSp.Id
+                    LEFT JOIN dbo.PartDefinitions AS parentDef ON parentSp.PartDefinitionId = parentDef.Id
+                    LEFT JOIN dbo.AspNetUsers AS u ON pl.OperatorId = u.Id
+                ');
+            ");
+        }
+    }
+}


### PR DESCRIPTION
## Bug Fix
This small pull request contains a database migration that fixes the part traceability view. This database view was referencing fields in the models and database schema that did not exist. To make this view functional again, these columns have been removed from the database view.

To get this change for your own database, remember to pull down the changes for your main branch and run the database update command from the `MESS.Data` directory.

```bash
dotnet ef database update --context ApplicationContext
```