### PR TITLE
Work Instruction Update Bug Fix

### DIFF
--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
@@ -824,9 +824,9 @@ public class WorkInstructionService : IWorkInstructionService
 
                 if (!await ValidateUniquenessAsync(dto, existing))
                     return false;
-
+                
                 await _workInstructionUpdater.ApplyAsync(dto, existing, context);
-
+                
                 await context.SaveChangesAsync();
                 await transaction.CommitAsync();
 

--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionService.cs
@@ -826,8 +826,6 @@ public class WorkInstructionService : IWorkInstructionService
                     return false;
 
                 await _workInstructionUpdater.ApplyAsync(dto, existing, context);
-                
-                await _partNodeResolver.ResolvePendingNodesAsync(context, existing.Nodes);
 
                 await context.SaveChangesAsync();
                 await transaction.CommitAsync();

--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionUpdater.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionUpdater.cs
@@ -24,6 +24,7 @@ namespace MESS.Services.CRUD.WorkInstructions;
 public class WorkInstructionUpdater : IWorkInstructionUpdater
 {
     private readonly IProductResolver _productResolver;
+    private readonly IPartNodeResolver _partNodeResolver;
     private readonly IPartDefinitionResolver _partDefinitionResolver;
     
     /// <summary>
@@ -31,10 +32,13 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
     /// </summary>
     /// <param name="productResolver">The service used for resolving products from product names.</param>
     /// <param name="partDefinitionResolver">The service used for resolving the part definition that a work instruction produces.</param>
-    public WorkInstructionUpdater(IProductResolver productResolver, IPartDefinitionResolver partDefinitionResolver)
+    /// <param name="partNodeResolver">The service used for resolving part nodes in a work instruction.</param>
+    public WorkInstructionUpdater(IProductResolver productResolver, IPartDefinitionResolver partDefinitionResolver,
+        IPartNodeResolver partNodeResolver)
     {
         _productResolver = productResolver;
         _partDefinitionResolver = partDefinitionResolver;
+        _partNodeResolver = partNodeResolver;
     }
     
     /// <summary>
@@ -88,6 +92,8 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         await SyncProductsAsync(dto, entity, context);
 
         SyncNodes(dto.Nodes, entity, context);
+        
+        await _partNodeResolver.ResolvePendingNodesAsync(context, entity.Nodes);
     }
     
     private void ApplyScalars(WorkInstructionFormDTO dto, WorkInstruction entity)

--- a/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionUpdater.cs
+++ b/MESS/MESS.Services/CRUD/WorkInstructions/WorkInstructionUpdater.cs
@@ -24,7 +24,6 @@ namespace MESS.Services.CRUD.WorkInstructions;
 public class WorkInstructionUpdater : IWorkInstructionUpdater
 {
     private readonly IProductResolver _productResolver;
-    private readonly IPartNodeResolver _partNodeResolver;
     private readonly IPartDefinitionResolver _partDefinitionResolver;
     
     /// <summary>
@@ -32,13 +31,10 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
     /// </summary>
     /// <param name="productResolver">The service used for resolving products from product names.</param>
     /// <param name="partDefinitionResolver">The service used for resolving the part definition that a work instruction produces.</param>
-    /// <param name="partNodeResolver">The service used for resolving part nodes in a work instruction.</param>
-    public WorkInstructionUpdater(IProductResolver productResolver, IPartDefinitionResolver partDefinitionResolver,
-        IPartNodeResolver partNodeResolver)
+    public WorkInstructionUpdater(IProductResolver productResolver, IPartDefinitionResolver partDefinitionResolver)
     {
         _productResolver = productResolver;
         _partDefinitionResolver = partDefinitionResolver;
-        _partNodeResolver = partNodeResolver;
     }
     
     /// <summary>
@@ -91,9 +87,7 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         await SyncPartProducedAsync(dto, entity, context);
         await SyncProductsAsync(dto, entity, context);
 
-        SyncNodes(dto.Nodes, entity, context);
-        
-        await _partNodeResolver.ResolvePendingNodesAsync(context, entity.Nodes);
+        await SyncNodes(dto.Nodes, entity, context);
     }
     
     private void ApplyScalars(WorkInstructionFormDTO dto, WorkInstruction entity)
@@ -113,7 +107,7 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         entity.Products = await _productResolver.ResolveProductsAsync(context, dto.ProductNames);
     }
     
-    private void SyncNodes(
+    private async Task SyncNodes(
         List<WorkInstructionNodeFormDTO> formNodes,
         WorkInstruction entity,
         ApplicationContext context)
@@ -138,11 +132,11 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         {
             if (dto.Id != 0 && existingById.TryGetValue(dto.Id, out var existing))
             {
-                ApplyToExisting(dto, existing);
+                await ApplyToExistingAsync(dto, existing, context);
             }
             else
             {
-                var newNode = CreateNew(dto);
+                var newNode = await CreateNewAsync(dto, context);
                 entity.Nodes.Add(newNode);
             }
         }
@@ -179,9 +173,10 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
             null);
     }
     
-    private void ApplyToExisting(
+    private async Task ApplyToExistingAsync(
         WorkInstructionNodeFormDTO dto,
-        WorkInstructionNode entity)
+        WorkInstructionNode entity,
+        ApplicationContext context)
     {
         entity.Position = dto.Position;
 
@@ -192,7 +187,7 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
                 break;
 
             case PartNodeFormDTO partDto when entity is PartNode part:
-                ApplyPartNode(partDto, part);
+                await ApplyPartNodeAsync(partDto, part, context);
                 break;
 
             default:
@@ -200,7 +195,9 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         }
     }
     
-    private WorkInstructionNode CreateNew(WorkInstructionNodeFormDTO dto)
+    private async Task<WorkInstructionNode> CreateNewAsync(
+        WorkInstructionNodeFormDTO dto,
+        ApplicationContext context)
     {
         return dto switch
         {
@@ -215,7 +212,7 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
                 SecondaryMedia = stepDto.SecondaryMedia.ToList()
             },
 
-            PartNodeFormDTO partDto => CreatePartNode(partDto),
+            PartNodeFormDTO partDto => await CreatePartNodeAsync(partDto, context),
 
             _ => throw new NotSupportedException()
         };
@@ -231,34 +228,42 @@ public class WorkInstructionUpdater : IWorkInstructionUpdater
         entity.SecondaryMedia = dto.SecondaryMedia.ToList();
     }
     
-    private void ApplyPartNode(PartNodeFormDTO dto, PartNode entity)
+    private async Task ApplyPartNodeAsync(
+        PartNodeFormDTO dto,
+        PartNode entity,
+        ApplicationContext context)
     {
         entity.InputType = dto.InputType;
 
-        // Store part info in a "pending resolution" way
-        entity.PartDefinitionId = 0; // Leave FK unset
-        entity.PartDefinition = new PartDefinition
-        {
-            Name = dto.Name,
-            Number = dto.Number
-        };
+        var part = await _partDefinitionResolver.ResolveAsync(
+                       context,
+                       dto.Name,
+                       dto.Number)
+                   ?? throw new InvalidOperationException(
+                       $"Failed to resolve PartDefinition '{dto.Name}' '{dto.Number}'.");
+
+        entity.PartDefinitionId = part.Id;
+        entity.PartDefinition = part;
     }
     
-    private PartNode CreatePartNode(PartNodeFormDTO partDto)
+    private async Task<PartNode> CreatePartNodeAsync(
+        PartNodeFormDTO dto,
+        ApplicationContext context)
     {
+        var part = await _partDefinitionResolver.ResolveAsync(
+                       context,
+                       dto.Name,
+                       dto.Number)
+                   ?? throw new InvalidOperationException(
+                       $"Failed to resolve PartDefinition '{dto.Name}' '{dto.Number}'.");
+
         return new PartNode
         {
             NodeType = WorkInstructionNodeType.Part,
-            Position = partDto.Position,
-            InputType = partDto.InputType,
-
-            // Store part info without FK; will be resolved later
-            PartDefinitionId = 0,
-            PartDefinition = new PartDefinition
-            {
-                Name = partDto.Name,
-                Number = partDto.Number
-            }
+            Position = dto.Position,
+            InputType = dto.InputType,
+            PartDefinitionId = part.Id,
+            PartDefinition = part
         };
     }
 }


### PR DESCRIPTION
## Bug Fix
This small pull request fixes a bug where when updating a work instruction, the `WorkInstructionUpdater` would create placeholder parts that would not properly be detected by the the `PartDefinitionResolver`. This would lead to errors when trying to update work instructions, especially with the PostgreSQL `PartDefinition` database constraints. This fix has been back-ported from the 1.1.0 Beta 1 pull request due to the bug's severity.

Additionally, this means the `WorkInstructionUpdater` class has been simplified to no longer call the `PartNodeResolver`.