### PR TITLE
Dark Mode Persistence Via User Profiles

### DIFF
--- a/MESS/MESS.Blazor/Components/Layout/MainLayout.razor
+++ b/MESS/MESS.Blazor/Components/Layout/MainLayout.razor
@@ -119,8 +119,8 @@
                 var user = await ApplicationUserService.GetByUserNameAsync(userName);
                 if (user != null)
                 {
-                    DarkModeInstance.Set(user.IsDarkMode);
-                    await JS.InvokeVoidAsync("setDarkMode", user.IsDarkMode);
+                    DarkModeInstance.Set(user.DarkMode);
+                    await JS.InvokeVoidAsync("setDarkMode", user.DarkMode);
                     StateHasChanged();
                 }
             }

--- a/MESS/MESS.Blazor/Components/Layout/MainLayout.razor
+++ b/MESS/MESS.Blazor/Components/Layout/MainLayout.razor
@@ -4,10 +4,12 @@
 @using System.ComponentModel
 @using MESS.Blazor.Components.Navigator
 @using MESS.Services.UI.DarkMode
+@using MESS.Services.CRUD.ApplicationUser
 @using Microsoft.AspNetCore.Components.Authorization
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthProvider
 @inject DarkModeInstance DarkModeInstance
+@inject IApplicationUserService ApplicationUserService
 
 <HeadContent>
     <script src="./Scripts/darkmode.js"></script>
@@ -77,7 +79,6 @@
     private bool isSidebarOpen = false;
     private bool ShowSidebarToggle = true;
     private bool ShowDarkModeToggle = true;
-    private bool isDarkMode = false;
 
     /// <summary>
     /// Called by the framework when parameters are set.
@@ -101,6 +102,29 @@
     protected override void OnInitialized()
     {
         DarkModeInstance.PropertyChanged += OnDarkModeChanged;
+    }
+
+    /// <summary>
+    /// Called after the component renders. On first render, loads the user's dark mode
+    /// preference from their profile and applies it.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var authState = await AuthProvider.GetAuthenticationStateAsync();
+            var userName = authState.User.Identity?.Name;
+            if (!string.IsNullOrEmpty(userName))
+            {
+                var user = await ApplicationUserService.GetByUserNameAsync(userName);
+                if (user != null)
+                {
+                    DarkModeInstance.Set(user.IsDarkMode);
+                    await JS.InvokeVoidAsync("setDarkMode", user.IsDarkMode);
+                    StateHasChanged();
+                }
+            }
+        }
     }
     
     private void OnDarkModeChanged(object? sender, PropertyChangedEventArgs e)
@@ -126,13 +150,23 @@
     }
 
     /// <summary>
-    /// Toggles dark mode by invoking the JS function and updates the icon.
+    /// Toggles dark mode, applies it via JS, and saves the preference to the user's profile.
     /// </summary>
     private async Task ToggleDarkMode()
     {
         DarkModeInstance.Toggle();
-        isDarkMode = !isDarkMode;
-        await JS.InvokeVoidAsync("toggleDarkMode", isDarkMode);
+        await JS.InvokeVoidAsync("toggleDarkMode");
+
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        var userName = authState.User.Identity?.Name;
+        if (!string.IsNullOrEmpty(userName))
+        {
+            var user = await ApplicationUserService.GetByUserNameAsync(userName);
+            if (user != null)
+            {
+                await ApplicationUserService.UpdateDarkModePreferenceAsync(user.Id, DarkModeInstance.IsDarkMode);
+            }
+        }
     }
 
     /// <summary>

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/MenuBar/MenuBarPhoebe.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/MenuBar/MenuBarPhoebe.razor
@@ -164,16 +164,19 @@
     Visible="@_showExportDialog"
     VisibleChanged="@(val => _showExportDialog = val)" />
 
-<ProductAssociationDialog
-    AllProducts="@Products"
-    SelectedProducts="@(ActiveDialog.SelectedProductNames)"
-    SelectedProductsChanged="OnDialogProductsChanged"
-    IsVisible="@ActiveDialog.IsVisible"
-    IsVisibleChanged="@(val => ActiveDialog.IsVisible = val)"
-    HeaderText="@ActiveDialog.HeaderText"
-    ConfirmButtonText="@ActiveDialog.ConfirmButtonText"
-    AllowsRenaming="@(ActiveDialog.Type == DialogType.SaveAs)"
-    OnConfirmed="HandleDialogConfirmed" />
+@if (Products is not null)
+{
+    <ProductAssociationDialog
+        AllProducts="@Products"
+        SelectedProducts="@(ActiveDialog.SelectedProductNames)"
+        SelectedProductsChanged="OnDialogProductsChanged"
+        IsVisible="@ActiveDialog.IsVisible"
+        IsVisibleChanged="@(val => ActiveDialog.IsVisible = val)"
+        HeaderText="@ActiveDialog.HeaderText"
+        ConfirmButtonText="@ActiveDialog.ConfirmButtonText"
+        AllowsRenaming="@(ActiveDialog.Type == DialogType.SaveAs)"
+        OnConfirmed="HandleDialogConfirmed" />
+}
 
 @code {
     private string? ActiveLineOperator { get; set; }

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/MenuBar/MenuBarPhoebe.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/MenuBar/MenuBarPhoebe.razor
@@ -4,6 +4,7 @@
 @using MESS.Blazor.Components.Pages.Phoebe.WorkInstruction
 @using MESS.Blazor.Components.Pages.Phoebe.WorkInstruction.Import
 @using MESS.Blazor.Components.Pages.Phoebe.WorkInstruction.Export
+@using MESS.Services.CRUD.ApplicationUser
 @using MESS.Services.CRUD.PartDefinitions
 @using MESS.Services.CRUD.WorkInstructions
 @using MESS.Services.DTOs.Products.Detail
@@ -15,6 +16,7 @@
 @using MESS.Services.UI.WorkInstructionEditor
 @inject AuthenticationStateProvider AuthProvider
 @inject IJSRuntime JS
+@inject IApplicationUserService ApplicationUserService
 @inject IWorkInstructionEditorService EditorService
 @inject IWorkInstructionService WorkInstructionService
 @inject IPartDefinitionService PartDefinitionService
@@ -399,10 +401,20 @@
 
     private async Task ToggleDarkMode()
     {
-        await JS.InvokeVoidAsync("document.body.classList.toggle", "dark-mode");
-        var isDark = await JS.InvokeAsync<bool>("document.body.classList.contains", "dark-mode");
-        _darkModeIcon = isDark ? "bi bi-sun" : "bi bi-moon-stars";
         DarkModeInstance.Toggle();
+        _darkModeIcon = DarkModeInstance.IsDarkMode ? "bi bi-sun" : "bi bi-moon-stars";
+        await JS.InvokeVoidAsync("toggleDarkMode");
+
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        var userName = authState.User.Identity?.Name;
+        if (!string.IsNullOrEmpty(userName))
+        {
+            var user = await ApplicationUserService.GetByUserNameAsync(userName);
+            if (user != null)
+            {
+                await ApplicationUserService.UpdateDarkModePreferenceAsync(user.Id, DarkModeInstance.IsDarkMode);
+            }
+        }
     }
 
     private async Task ToggleSidebar()

--- a/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/Export/WorkInstructionExportDialog.razor
+++ b/MESS/MESS.Blazor/Components/Pages/Phoebe/WorkInstruction/Export/WorkInstructionExportDialog.razor
@@ -32,13 +32,16 @@
         </FluentDialogBody>
 
         <FluentDialogFooter>
-            <WorkInstructionExportButton 
-                @ref="_exportButton"
-                WorkInstruction="WorkInstruction"
-                OnDownloadComplete="Close"
-                OnDownloadStateChanged="HandleDownloadStateChanged"
-                OnProgressChanged="HandleProgressChanged"/>
-            
+            @if (WorkInstruction is not null)
+            {
+                <WorkInstructionExportButton 
+                    @ref="_exportButton"
+                    WorkInstruction="WorkInstruction"
+                    OnDownloadComplete="Close"
+                    OnDownloadStateChanged="HandleDownloadStateChanged"
+                    OnProgressChanged="HandleProgressChanged"/>
+            }
+
             <button type="button"
                     class="btn btn-sm btn-outline-secondary"
                     @onclick="CancelExport">

--- a/MESS/MESS.Blazor/Program.cs
+++ b/MESS/MESS.Blazor/Program.cs
@@ -119,7 +119,7 @@ builder.Services.AddAntiforgery();
 // Setup FluentUI
 builder.Services.AddFluentUIComponents();
 
-builder.Services.AddSingleton<DarkModeInstance>();
+builder.Services.AddScoped<DarkModeInstance>();
 
 
 

--- a/MESS/MESS.Blazor/wwwroot/Scripts/darkmode.js
+++ b/MESS/MESS.Blazor/wwwroot/Scripts/darkmode.js
@@ -172,6 +172,12 @@ window.toggleDarkMode = function () {
     applyTheme(manualOverride);
 };
 
+window.setDarkMode = function (isDark) {
+    manualOverride = isDark;
+    localStorage.setItem("manualDarkMode", isDark ? "dark" : "light");
+    applyTheme(isDark);
+};
+
 window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", e => {
     currentDark = e.matches;
     if (manualOverride === null) {

--- a/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.Designer.cs
+++ b/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using MESS.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MESS.Data.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20260324024445_AddDarkModePreference")]
+    partial class AddDarkModePreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.Designer.cs
+++ b/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.Designer.cs
@@ -66,7 +66,7 @@ namespace MESS.Data.Migrations
                     b.Property<bool>("IsActive")
                         .HasColumnType("boolean");
 
-                    b.Property<bool>("IsDarkMode")
+                    b.Property<bool>("DarkMode")
                         .HasColumnType("boolean");
 
                     b.Property<string>("LastName")

--- a/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.cs
+++ b/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.cs
@@ -11,7 +11,7 @@ namespace MESS.Data.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<bool>(
-                name: "IsDarkMode",
+                name: "DarkMode",
                 table: "AspNetUsers",
                 type: "boolean",
                 nullable: false,
@@ -22,7 +22,7 @@ namespace MESS.Data.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
-                name: "IsDarkMode",
+                name: "DarkMode",
                 table: "AspNetUsers");
         }
     }

--- a/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.cs
+++ b/MESS/MESS.Data/Migrations/20260324024445_AddDarkModePreference.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MESS.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDarkModePreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDarkMode",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsDarkMode",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/MESS/MESS.Data/Migrations/ApplicationContextModelSnapshot.cs
+++ b/MESS/MESS.Data/Migrations/ApplicationContextModelSnapshot.cs
@@ -63,7 +63,7 @@ namespace MESS.Data.Migrations
                     b.Property<bool>("IsActive")
                         .HasColumnType("boolean");
 
-                    b.Property<bool>("IsDarkMode")
+                    b.Property<bool>("DarkMode")
                         .HasColumnType("boolean");
 
                     b.Property<string>("LastName")

--- a/MESS/MESS.Data/Models/ApplicationUser.cs
+++ b/MESS/MESS.Data/Models/ApplicationUser.cs
@@ -31,6 +31,11 @@ public class ApplicationUser : IdentityUser
     public List<int>? ProductionLogIds { get; set; }
     
     /// <summary>
+    /// Gets or sets a value indicating whether the user prefers dark mode.
+    /// </summary>
+    public bool IsDarkMode { get; set; }
+
+    /// <summary>
     /// Gets the full name of the user by combining the first and last names.
     /// </summary>
     public string FullName => $"{FirstName} {LastName}";

--- a/MESS/MESS.Data/Models/ApplicationUser.cs
+++ b/MESS/MESS.Data/Models/ApplicationUser.cs
@@ -33,7 +33,7 @@ public class ApplicationUser : IdentityUser
     /// <summary>
     /// Gets or sets a value indicating whether the user prefers dark mode.
     /// </summary>
-    public bool IsDarkMode { get; set; }
+    public bool DarkMode { get; set; }
 
     /// <summary>
     /// Gets the full name of the user by combining the first and last names.

--- a/MESS/MESS.Services/CRUD/ApplicationUser/ApplicationUserService.cs
+++ b/MESS/MESS.Services/CRUD/ApplicationUser/ApplicationUserService.cs
@@ -318,4 +318,21 @@ public class ApplicationUserService : IApplicationUserService
 
         return csv;
     }
+
+    /// <inheritdoc />
+    public async Task<bool> UpdateDarkModePreferenceAsync(string userId, bool isDarkMode)
+    {
+        try
+        {
+            var updated = await _context.Users
+                .Where(u => u.Id == userId)
+                .ExecuteUpdateAsync(s => s.SetProperty(u => u.IsDarkMode, isDarkMode));
+            return updated > 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error updating dark mode preference for user {UserId}", userId);
+            return false;
+        }
+    }
 }

--- a/MESS/MESS.Services/CRUD/ApplicationUser/ApplicationUserService.cs
+++ b/MESS/MESS.Services/CRUD/ApplicationUser/ApplicationUserService.cs
@@ -326,7 +326,7 @@ public class ApplicationUserService : IApplicationUserService
         {
             var updated = await _context.Users
                 .Where(u => u.Id == userId)
-                .ExecuteUpdateAsync(s => s.SetProperty(u => u.IsDarkMode, isDarkMode));
+                .ExecuteUpdateAsync(s => s.SetProperty(u => u.DarkMode, isDarkMode));
             return updated > 0;
         }
         catch (Exception ex)

--- a/MESS/MESS.Services/CRUD/ApplicationUser/IApplicationUserService.cs
+++ b/MESS/MESS.Services/CRUD/ApplicationUser/IApplicationUserService.cs
@@ -95,4 +95,12 @@ public interface IApplicationUserService
     /// </summary>
     /// <returns>A CSV string representing all users and their roles.</returns>
     Task<string> ExportUsersToCsvAsync();
+
+    /// <summary>
+    /// Updates the dark mode preference for a user.
+    /// </summary>
+    /// <param name="userId">The user's ID.</param>
+    /// <param name="isDarkMode">True to enable dark mode; false to disable it.</param>
+    /// <returns>True if successful; otherwise false.</returns>
+    Task<bool> UpdateDarkModePreferenceAsync(string userId, bool isDarkMode);
 }


### PR DESCRIPTION
## New Feature
A user's theme choice (light or dark mode) is now stored in the database via a boolean named ``DarkMode`` located in in the ``ApplicationUser`` model. 

## Important Note
A database migration is required for MESS deployments and development environments tracking the main branch.